### PR TITLE
Unpack Components - About Section 1

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -2,17 +2,17 @@
   "gaw": "GAW",
   "gawFull": "Global Atmosphere Watch",
   "note": "Note",
+  "wafFull": "Web Accessible Folder",
   "welcome": "Welcome",
   "wmo": "WMO",
   "wmoFull": "World Meteorological Organization",
   "woudcFull": "World Ozone and Ultraviolet Radiation Data Centre",
   "about": {
     "access": {
-      "blurb": [
-        "Access to the WOUDC data archive is available via numerous mechanisms in support of vendor neutral, multi-application access and integration. Whether you are using the website, geospatial tools or custom solutions, the WOUDC data archive provides flexible, authoritative data access.",
-        "Every effort has been made to make the WOUDC data archive as accessible as possible. If you have any questions, comments, or suggestions on improving data access, please ",
-        "contact us"
-      ],
+      "blurb": {
+        "contact": "contact us",
+        "template": "Access to the WOUDC data archive is available via numerous mechanisms in support of vendor neutral, multi-application access and integration. Whether you are using the website, geospatial tools or custom solutions, the WOUDC data archive provides flexible, authoritative data access.\n\nEvery effort has been made to make the WOUDC data archive as accessible as possible. If you have any questions, comments, or suggestions on improving data access, please {contact}."
+      },
       "contents": {
         "links": [
           "Data Search / Download",
@@ -29,16 +29,12 @@
         "title": "Table of Contents"
       },
       "csw": {
-        "blurb": [
-          "The ",
-          "OGC Catalogue Service",
-          " provides a common interface to discover, browse and query discovery metadata (data about data). The WOUDC CSW provides a yellow pages catalogue of all WOUDC data available in the archive. Metadata records are formatted using the ISO 19115/19139 geospatial metadata standards."
-        ],
+        "blurb": {
+          "ogc": "OGC Catalogue Service",
+          "template": "The {ogc} provides a common interface to discover, browse and query discovery metadata (data about data). The WOUDC CSW provides a yellow pages catalogue of all WOUDC data available in the archive. Metadata records are formatted using the ISO 19115/19139 geospatial metadata standards."
+        },
         "note": {
-          "body": [
-            "WOUDC provides OGC CSW (version 2.0.2) at the following endpoint: ",
-            "https://geo.woudc.org/csw?service=CSW&version=2.0.2&request=GetCapabilities"
-          ],
+          "template": "WOUDC provides OGC CSW (version 2.0.2) at the following endpoint: {link}",
           "title": "WOUDC OGC CSW"
         },
         "title": "Catalogue Service for the Web (CSW)"
@@ -46,20 +42,16 @@
       "definitions": {
         "blurb": "Web Services are modelled and managed using a data taxonomy. An RDF-based definitions service exists to describe WOUDC's data taxonomy and relationships.",
         "note": {
-          "body": [
-            "WOUDC provides RDF/SKOS at the following endpoint: ",
-            "https://geo.woudc.org/def"
-          ],
+          "template": "WOUDC provides RDF/SKOS at the following endpoint: {link}",
           "title": "WOUDC Definitions Service"
         },
         "title": "Definitions Service"
       },
       "examples": {
-        "blurb": [
-          "The following ",
-          "GitHub",
-          " examples provide high level access and workflow examples of integrating WOUDC Web Services:"
-        ],
+        "blurb": {
+          "github": "GitHub",
+          "template": "The following {github} examples provide high level access and workflow examples of integrating WOUDC Web Services:"
+        },
         "links": [
           "High level package providing Pythonic access to WMO WOUDC data services",
           "A collection of data centre workflows implemented as IPython notebooks"
@@ -68,75 +60,56 @@
       },
       "iso": {
         "blurb1": "Codelists are managed using the ISO 19115 standard. An ISO 19115 codelist catalogue exists to describe various WOUDC's domain objects for use in metadata.",
-        "blurb2": [
-          "Please consult the ",
-          "Web Services How To",
-          " for detailed information."
-        ],
+        "blurb2": {
+          "how-to": "Web Services How To",
+          "template": "Please consult the {how-to} for detailed information."
+        },
         "note": {
-          "body": [
-            "WOUDC provides the ISO Codelist Catalogue at the following endpoint: ",
-            "https://geo.woudc.org/codelists.xml"
-          ],
+          "template": "WOUDC provides the ISO Codelist Catalogue at the following endpoint: {link}",
           "title": "WOUDC Codelist Catalogue"
         },
         "title": "ISO Codelist Catalogue"
       },
       "note1": {
-        "body": [
-          "All data and metadata are subject to the WOUDC ",
-          "data policy"
-        ],
+        "body": {
+          "policy": "data policy",
+          "template": "All data and metadata are subject to the WOUDC {policy}"
+        },
         "title": "Data Policy"
       },
       "note2": {
-        "body": [
-          "The data revision dates are available on the ",
-          "stations list",
-          " for stations that have provided revised data."
-        ],
+        "body": {
+          "stations": "stations list",
+          "template": "The data revision dates are available on the {stations} for stations that have provided revised data."
+        },
         "title": "Data Revisions/Updates"
       },
       "search": {
-        "blurb": [
-          "Observation data are made available via the ",
-          "data search / download",
-          " page, which allows users to browse and filter the entire archive in a responsive, interactive manner. All data provide a link to download data for offline use in a variety of formats.",
-          "Please consult the ",
-          "Data Search / Download How To",
-          " for detailed information."
-        ],
+        "blurb": {
+          "how-to": "Data Search / Download How To",
+          "search": "data search / download",
+          "template": "Observation data are made available via the {search} page, which allows users to browse and filter the entire archive in a responsive, interactive manner. All data provide a link to download data for offline use in a variety of formats.\n\nPlease consult the {how-to} for detailed information."
+        },
         "note": " Please note that dataset specific limits are put on bulk data download to maintain quality of service.",
         "title": "Data Search / Download"
       },
       "title": "Data Access",
       "waf": {
-        "blurb": [
-          "The entire archive of contributed data files in Extended CSV format is made available at ",
-          "https://woudc.org/archive/",
-          " for users to browse, download or integrate into their workflows.",
-          " Static dataset ",
-          "archive files",
-          " are also available on the WAF in CSV format with ZIP compression. These archive files are updated on a daily basis and provide users the option to download an entire dataset in CSV format.",
-          "Please consult the ",
-          "WAF How To",
-          " for detailed information."
-        ],
+        "blurb": {
+          "how-to": "WAF How To",
+          "summary": "archive files",
+          "template": "The entire archive of contributed data files in Extended CSV format is made available at {waf} for users to browse, download or integrate into their workflows.\n\nStatic dataset {summary} are also available on the WAF in CSV format with ZIP compression. These archive files are updated on a daily basis and provide users the option to download an entire dataset in CSV format.\n\nPlease consult the {how-to} for detailed information."
+        },
         "title": "Web Accessible Folder (WAF)"
       },
       "web": {
-        "blurb": [
-          "In addition to traditional data access mechanisms, WOUDC has made the archive available using geospatial web services adhering to publically available international standards. Web services are systems designed to support machine to machine interaction over a network, and are typically utilized in a client/server computing environment made available through programmatic access, associated tools and applications.",
-          "The WOUDC web services adhere to open standards ratified by the ",
-          "Open Geospatial Consortium",
-          " (OGC), and the ",
-          "International Organization for Standardization",
-          " (ISO) which enable interoperability and thus make data easy to discover, access, visualize and integrate. OGC and ISO standards play an important role in ",
-          "World Meteorological Organization interoperability" ,
-          " as part of the ",
-          "WMO Information System",
-          " and are supported by numerous off the shelf open source or commercial tools."
-        ],
+        "blurb": {
+          "interoperability": "World Meteorological Organization interoperability" ,
+          "iso": "International Organization for Standardization",
+          "ogc": "Open Geospatial Consortium",
+          "template": "In addition to traditional data access mechanisms, WOUDC has made the archive available using geospatial web services adhering to publically available international standards. Web services are systems designed to support machine to machine interaction over a network, and are typically utilized in a client/server computing environment made available through programmatic access, associated tools and applications.\n\nThe WOUDC web services adhere to open standards ratified by the {ogc} (OGC), and the {iso} (ISO) which enable interoperability and thus make data easy to discover, access, visualize and integrate. OGC and ISO standards play an important role in {interoperability} as part of the {wis} and are supported by numerous off the shelf open source or commercial tools.",
+          "wis": "WMO Information System"
+        },
         "table": {
           "links": [ "???" ],
           "title": "The following OGC web services are made available for standards-based, dynamic data access:"
@@ -144,46 +117,34 @@
         "title": "Web Services"
       },
       "wfs": {
-        "blurb": [
-          "The ",
-          "OGC Web Feature Service",
-          " provides a common interface to access geospatial data. Typical use of WFS includes custom query / raw access to geospatial features. The WOUDC WFS provides archive data in numerous formats, including Extended CSV, KML, CSV, GML, ESRI Shapefile, MapInfo, GeoJSON, and NetCDF.\n\nThe WFS has a server side limit of a maximum of 200000 features to ensure quality of service and availability."
-        ],
+        "blurb": {
+          "template": "The {wfs} provides a common interface to access geospatial data. Typical use of WFS includes custom query / raw access to geospatial features. The WOUDC WFS provides archive data in numerous formats, including Extended CSV, KML, CSV, GML, ESRI Shapefile, MapInfo, GeoJSON, and NetCDF.\n\nThe WFS has a server side limit of a maximum of 200000 features to ensure quality of service and availability.",
+          "wfs": "OGC Web Feature Service"
+        },
         "note": {
-          "body": [
-            "WOUDC provides OGC WFS (versions 1.0.0 - 1.1.0) at the following endpoint: ",
-            "https://geo.woudc.org/ows?service=WFS&version=1.1.0&request=GetCapabilities"
-          ],
+          "template": "WOUDC provides OGC WFS (versions 1.0.0 - 1.1.0) at the following endpoint: {link}",
           "title": "WOUDC OGC WFS"
         },
         "title": "Web Feature Service (WFS)"
       },
       "wms": {
-        "blurb": [
-          "The ",
-          "OGC Web Map Service",
-          " provides a common interface to visualize geospatial data layers. Typical use of WMS includes simple visualization in web or desktop GIS applications via web friendly image formats such as PNG or JPEG."
-        ],
+        "blurb": {
+          "template": "The {wms} provides a common interface to visualize geospatial data layers. Typical use of WMS includes simple visualization in web or desktop GIS applications via web friendly image formats such as PNG or JPEG.",
+          "wms": "OGC Web Map Service"
+        },
         "note": {
-          "body": [
-            "WOUDC provides OGC WMS (versions 1.1.1 - 1.3.0) at the following endpoint: ",
-            "https://geo.woudc.org/ows?service=WMS&version=1.3.0&request=GetCapabilities"
-          ],
+          "template": "WOUDC provides OGC WMS (versions 1.1.1 - 1.3.0) at the following endpoint: {link}",
           "title": "WOUDC OGC WMS"
         },
         "title": "Web Map Service (WMS)"
       },
       "wps": {
-        "blurb": [
-          "The ",
-          "OGC Web Processing Service",
-          " provides a common interface to define rules, inputs, outputs for geospatial processing / calculations. Typical use of WPS includes custom processes (buffer, overlay). The WOUDC WPS provides a suite of tools used in support of validation of submissions to the Data Centre."
-        ],
+        "blurb": {
+          "template": "The {wps} provides a common interface to define rules, inputs, outputs for geospatial processing / calculations. Typical use of WPS includes custom processes (buffer, overlay). The WOUDC WPS provides a suite of tools used in support of validation of submissions to the Data Centre.",
+          "wps": "OGC Web Processing Service"
+        },
         "note": {
-          "body": [
-            "WOUDC provides OGC WPS (version 1.0.0) at the following endpoint: ",
-            "https://geo.woudc.org/wps?service=WPS&version=1.0.0&request=GetCapabilities"
-          ],
+          "template": "WOUDC provides OGC WPS (version 1.0.0) at the following endpoint: {link}",
           "title": "WOUDC OGC WPS"
         },
         "title": "Web Processing Service (WPS)"
@@ -690,18 +651,16 @@
       "title": "About WOUDC"
     },
     "policy": {
-      "blurb": [
-        "Use of the WOUDC data are governed by the ",
-        "World Meteorological Organization (WMO) data policy",
-        " and ",
-        "WMO Global Atmosphere Watch (GAW) data use policy"
-      ],
+      "blurb": {
+        "gaw": "WMO Global Atmosphere Watch (GAW) data use policy",
+        "template": "Use of the WOUDC data are governed by the {wmo} and {gaw}.",
+        "wmo": "World Meteorological Organization (WMO) data policy"
+      },
       "doi": {
-        "blurb": [
-          "WOUDC has registered ",
-          "DOIs",
-          " for both Ozone and UV data. DOIs are persistent identifiers that allow research data to be accessible and citable. They make research data easier to access, reuse and verify, thereby making it easier to build on previous work, conduct new research and avoid duplicating already existing work."
-        ],
+        "blurb": {
+          "dois": "DOIs",
+          "template": "WOUDC has registered {dois} for both Ozone and UV data. DOIs are persistent identifiers that allow research data to be accessible and citable. They make research data easier to access, reuse and verify, thereby making it easier to build on previous work, conduct new research and avoid duplicating already existing work."
+        },
         "note1": {
           "items": [
             "Ozone: doi:10.14287/10000001",
@@ -745,10 +704,10 @@
       },
       "publishing": {
         "blurb1": "When publishing data retrieved from the WOUDC you are expected to acknowledge the contributors who author these data as the data source and the WOUDC, using the appropriate citation as per the example provided.",
-        "blurb2": [
-          "For a complete list of all contributors refer to the ",
-          "contributor list"
-        ],
+        "blurb2": {
+          "contributors": "contributor list",
+          "template": "For a complete list of all contributors refer to the {contributors}."
+        },
         "note1": {
           "body": "JMA, & NASA-WFF. World Meteorological Organization-Global Atmosphere Watch Program (WMO-GAW)/World Ozone and Ultraviolet Radiation Data Centre (WOUDC) [Data]. Retrieved October 24, 2013, from https://woudc.org. doi:10.14287/10000001",
           "title": "Example (1): Citation for ozone data originating (contributed) from the Japan Meteorological Agency (JMA) and NASA (NASA-WFF) retrieved from the WOUDC site"
@@ -764,11 +723,10 @@
       },
       "title": "Data Use Policy",
       "wmo": {
-        "blurb": [
-          "The WMO facilitates the free and unrestricted exchange of data and information, products and services in real or near-real time on matters relating to safety and security of society, economic welfare and the protection of the environment.",
-          "Resolution 40 (Cg-XII)",
-          " WMO policy and practice for the exchange of meteorological and related data and products including guidelines on the relationships in commercial meteorological activities."
-        ],
+        "blurb": {
+          "link": "Resolution 40 (Cg-XII)",
+          "template": "The WMO facilitates the free and unrestricted exchange of data and information, products and services in real or near-real time on matters relating to safety and security of society, economic welfare and the protection of the environment.\n\n{link} WMO policy and practice for the exchange of meteorological and related data and products including guidelines on the relationships in commercial meteorological activities."
+        },
         "title": "World Meteorological Organization Data Policy"
       }
     },
@@ -776,42 +734,29 @@
       "blurb": "The WOUDC data are subject to the Global Atmosphere Watch quality assurance system and the oversight of the Scientific Advisory Groups on ozone and solar ultraviolet radiation.",
       "eccc": {
         "blurb": "The WOUDC is operated by the Department of the Environment (referred to as Environment and Climate Change Canada) and undertakes the following activities:",
-        "item1": [
-          "Provides ",
-          "guidelines",
-          " for submitting data;"
-        ],
-        "item2": [
-          "Checks submitted data for necessary format elements and the availability of comprehensive metadata and reject the submission of data that do not meet these formal criteria;"
-        ],
-        "item3": [
-          "Performs plausibility and consistency checks on submitted data, flag data problems, and provide feedback to the stations, when necessary;"
-        ],
-        "item4": [
-          "Provides collection of data user feedback;"
-        ],
-        "item5": [
-          "Shares results of quality assessment and user feedback with data contributors so that data can be corrected or corrective actions can be taken as required; and"
-        ],
-        "item6": [
-          "Provides ",
-          "data access",
-          " mechanisms."
-        ],
+        "item1": {
+          "guidelines": "guidelines",
+          "template": "Provides {guidelines} for submitting data;"
+        },
+        "item2": "Checks submitted data for necessary format elements and the availability of comprehensive metadata and reject the submission of data that do not meet these formal criteria;",
+        "item3": "Performs plausibility and consistency checks on submitted data, flag data problems, and provide feedback to the stations, when necessary;",
+        "item4": "Provides collection of data user feedback;",
+        "item5": "Shares results of quality assessment and user feedback with data contributors so that data can be corrected or corrective actions can be taken as required; and",
+        "item6": {
+          "access": "data access",
+          "template": "Provides {access} mechanisms."
+        },
         "title": "Environment and Climate Change Canada"
       },
-      "gaw-blurb": [
-        "The primary objectives of the ",
-        "GAW quality assurance system",
-        " are to ensure that the data in the World Data Centres are consistent, of known and adequate quality, supported by comprehensive metadata, and sufficiently complete to describe global atmospheric states with respect to spatial and temporal distribution."
-      ],
+      "gaw-blurb": {
+        "gaw-qa": "GAW quality assurance system",
+        "template": "The primary objectives of the {gaw-qa} are to ensure that the data in the World Data Centres are consistent, of known and adequate quality, supported by comprehensive metadata, and sufficiently complete to describe global atmospheric states with respect to spatial and temporal distribution."
+      },
       "sag": {
-        "blurb":  [
-          "The SAG on ozone and solar ultraviolet radiation establish data quality objectives and ",
-          "standard operating procedures",
-          " outlining measurement methods and procedures.",
-          "The SAG ensure that all data produced by the system conform to international standards, via the following calibration centres:"
-        ],
+        "blurb": {
+          "sop": "standard operating procedures",
+          "template": "The SAG on ozone and solar ultraviolet radiation establish data quality objectives and {sop} outlining measurement methods and procedures.\n\nThe SAG ensure that all data produced by the system conform to international standards, via the following calibration centres:"
+        },
         "links": [
           {
             "text": "WMO GAW World Calibration Centre for Dobson total ozone measurements",
@@ -831,70 +776,42 @@
       "title": "Data Quality"
     },
     "standards": {
-      "blurb1": [
-        "WOUDC adheres to open standards which enable interoperability (discovery, access, visualization). Standards play an important role in ",
-        "World Meteorological Organization interoperability",
-        " as part of the ",
-        "WMO Information System",
-        " and are supported by numerous off the shelf open source or commercial tools."
-      ],
-      "blurb2": [
-        "More information can be found on the ",
-        "Data Access page"
-      ],
+      "blurb1": {
+        "interoperability": "World Meteorological Organization interoperability",
+        "template": "WOUDC adheres to open standards which enable interoperability (discovery, access, visualization). Standards play an important role in {interoperability} as part of the {wis} and are supported by numerous off the shelf open source or commercial tools.",
+        "wis": "WMO Information System"
+      },
+      "blurb2": {
+        "access": "Data Access page",
+        "template": "More information can be found on the {access}."
+      },
       "headers": [
         "Resources",
         "Format/Encoding",
         "Service/API"
       ],
-      "links": [
-        {
-          "resource": "Discovery Metadata",
-          "formats": [
-            "ISO 19115 WMO Core Metadata Profile"
-          ],
-          "services": [
-            "OGC:CSW",
-            "OAI-PMH",
-            "OpenSearch"
-          ]
+      "links": {
+        "resources": [
+          "Discovery Metadata",
+          "Station Metadata",
+          "Instrument Metadata",
+          "Observations"
+        ],
+        "formats": {
+          "csv": "CSV",
+          "geojson": "GeoJSON",
+          "gml": "OGC:GML",
+          "iso": "ISO 19115 WMO Core Metadata Profile",
+          "wigos": "WIGOS"
         },
-        {
-          "resource": "Station Metadata",
-          "formats": [
-            "OGC:GML",
-            "WIGOS"
-          ],
-          "services": [
-            "OGC:WMS",
-            "OGC:WFS"
-          ]
-        },
-        {
-          "resource": "Instrument Metadata",
-          "formats": [
-            "OGC:GML",
-            "WIGOS"
-          ],
-          "services": [
-            "OGC:WMS",
-            "OGC:WFS"
-          ]
-        },
-        {
-          "resource": "Observations",
-          "formats": [
-            "CSV",
-            "GeoJSON",
-            "OGC:GML",
-            "WIGOS"
-          ],
-          "services": [
-            "OGC:WMS",
-            "OGC:WFS"
-          ]
+        "services": {
+          "csw": "OGC:CSW",
+          "opensearch": "OpenSearch",
+          "pmh": "OAI-PMH",
+          "wfs": "OGC:WFS",
+          "wms": "OGC:WMS"
         }
-      ],
+      },
       "title": "Standards"
     }
   },

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -2,17 +2,17 @@
   "gaw": "VAG",
   "gawFull": "Veille de l'atmosphère globale",
   "note": "Remarque",
+  "wafFull": "Dossier Accessible sur le Web",
   "welcome": "Bienvenue",
   "wmo": "OMM",
   "wmoFull": "Organisation météorologique mondiale",
   "woudcFull": "Centre mondial de données sur l’ozone et le rayonnement ultraviolet",
   "about": {
     "access": {
-      "blurb": [
-        "L’accès aux données archivées du WOUDC est possible par l’entremise de nombreux mécanismes en appui à une accessibilité multi-application non rattachée à un fournisseur donné. Que vous utilisiez le site web, les outils géospatiaux ou nos solutions personnalisées, les archives de données du WOUDC fournissent une accessibilité souple et officielle en plus de vous permettre l’accès aux données.",
-        "Tous les efforts ont été déployés pour rendre les archives de données du WOUDC aussi accessibles que possible. Si vous avez des questions, des commentaires ou des suggestions sur la façon dont nous pourrions améliorer l’accès aux données, veuillez ",
-        "nous contacter"
-      ],
+      "blurb": {
+        "contact": "nous contacter",
+        "template": "L’accès aux données archivées du WOUDC est possible par l’entremise de nombreux mécanismes en appui à une accessibilité multi-application non rattachée à un fournisseur donné. Que vous utilisiez le site web, les outils géospatiaux ou nos solutions personnalisées, les archives de données du WOUDC fournissent une accessibilité souple et officielle en plus de vous permettre l’accès aux données.\n\nTous les efforts ont été déployés pour rendre les archives de données du WOUDC aussi accessibles que possible. Si vous avez des questions, des commentaires ou des suggestions sur la façon dont nous pourrions améliorer l’accès aux données, veuillez {contact}."
+      },
       "contents": {
         "links": [
           "Rechercher des données / Télécharger",
@@ -29,16 +29,12 @@
         "title": "Table des matières"
       },
       "csw": {
-        "blurb": [
-          "Le ",
-          "service de catalogue de l’OGC",
-          " fournit une interface commune pour permettre à l’usager de découvrir, de parcourir et de faire des recherches de métadonnées (des données au sujet des données) facilement. Le CSW du WOUDC fournit un catalogue de type Pages Jaunes de toutes les données du WOUDC disponibles dans les archives. Les registres de métadonnées sont formatés selon les normes du contenu des métadonnées géospatiales ISO 19115/19139."
-        ],
+        "blurb": {
+          "policy": "service de catalogue de l’OGC",
+          "template": "Le {policy} fournit une interface commune pour permettre à l’usager de découvrir, de parcourir et de faire des recherches de métadonnées (des données au sujet des données) facilement. Le CSW du WOUDC fournit un catalogue de type Pages Jaunes de toutes les données du WOUDC disponibles dans les archives. Les registres de métadonnées sont formatés selon les normes du contenu des métadonnées géospatiales ISO 19115/19139."
+        },
         "note": {
-          "body": [
-            "Le WOUDC donne accès au CSW de l’OGC (version 2.0.2) à ces différents endroits : ",
-            "https://geo.woudc.org/csw?service=CSW&version=2.0.2&request=GetCapabilities"
-          ],
+          "template": "Le WOUDC donne accès au CSW de l’OGC (version 2.0.2) à ces différents endroits : {link}",
           "title": "Le WOUDC et le CSW de l’OGC"
         },
         "title": "Service de catalogue pour le web (CSW)"
@@ -46,20 +42,16 @@
       "definitions": {
         "blurb": "Les services web sont modélisés et gérés grâce à une taxonomie des données. Il existe un service dedéfinitions, fondé sur un modèle RDF, servant à décrire la taxonomie des données du WOUDC et les liens qui les unissent.",
         "note": {
-          "body": [
-            "Le WOUDC fournit le modèle RDF/SKOS aux endroits suivants : ",
-            "https://geo.woudc.org/def"
-          ],
+          "template": "Le WOUDC fournit le modèle RDF/SKOS aux endroits suivants : {link}",
           "title": "Le service de définitions du WOUDC"
         },
         "title": "Service de définitions"
       },
       "examples": {
-        "blurb": [
-          "Les exemples ",
-          "GitHub",
-          " suivants démontrent l’accessibilité de haut niveau et l’intégration dans les flux de travaux des Services Web du WOUDC :"
-        ],
+        "blurb": {
+          "github": "GitHub",
+          "template": "Les exemples {github} suivants démontrent l’accessibilité de haut niveau et l’intégration dans les flux de travaux des Services Web du WOUDC :"
+        },
         "links": [
           "L’ensemble de haut niveau permet un accès pythonique aux données de l’OMM et du WOUDC",
           "Et regroupe toute une collection de flux de travaux provenant de divers centres de données qui sont implémentés comme cahiers IPython"
@@ -68,75 +60,56 @@
       },
       "iso": {
         "blurb1": "Les listes de codes sont gérées en conformité avec la norme ISO 19115. Il existe un catalogue répertoriant les listes de codes servant à décrire une variété d’objets de domaine du WOUDC servant dans les métadonnées.",
-        "blurb2": [
-          "Veuillez consulter les ",
-          "instructions pour les services web",
-          " pour plus de détails."
-        ],
+        "blurb2": {
+          "how-to": "instructions pour les services web",
+          "template": "Veuillez consulter les {how-to} pour plus de détails."
+        },
         "note": {
-          "body": [
-            "Le WOUDC donne accès au catalogue des listes de codes aux endroits suivants : ",
-            "https://geo.woudc.org/codelists.xml"
-          ],
+          "template": "Le WOUDC donne accès au catalogue des listes de codes aux endroits suivants : {link}",
           "title": "Catalogue répertoriant les listes de codes du WOUDC"
         },
         "title": "Catalogue des listes de codes ISO"
       },
       "note1": {
-        "body": [
-          "Toutes les données et métadonnées sont assujetties à la ",
-          "politique en matière de données du WOUDC"
-        ],
+        "body": {
+          "policy": "politique en matière de données du WOUDC",
+          "template": "Toutes les données et métadonnées sont assujetties à la {policy}"
+        },
         "title": "Politiques en matière de données"
       },
       "note2": {
-        "body": [
-          "Les dates de révision des données sont disponibles à ",
-          "stations list",
-          " pour les postes qui ont fourni des données révisées."
-        ],
+        "body": {
+          "stations": "stations list",
+          "template": "Les dates de révision des données sont disponibles à {stations} pour les postes qui ont fourni des données révisées."
+        },
         "title": "Révisions de données / mises à jour"
       },
       "search": {
-        "blurb": [
-          "Les données d’observation sont accessibles via ",
-          "la page Recherche de données / Téléchargement",
-          " qui permet aux usagers de parcourir l’ensemble des archives et de filtrer les résultats d’une façon réceptive et interactive. Toutes les données offrent un lien qui permet de télécharger les données dans divers formats pour une utilisation hors ligne.",
-          "Veuillez consulter les ",
-          "instructions de recherche / téléchargement de données",
-          " pour plus de détails."
-        ],
+        "blurb": {
+          "how-to": "instructions de recherche / téléchargement de données",
+          "search": "la page Recherche de données / Téléchargement",
+          "template": "Les données d’observation sont accessibles via {search} qui permet aux usagers de parcourir l’ensemble des archives et de filtrer les résultats d’une façon réceptive et interactive. Toutes les données offrent un lien qui permet de télécharger les données dans divers formats pour une utilisation hors ligne.\n\nVeuillez consulter les {how-to} pour plus de détails."
+        },
         "note": " Veuillez noter que des limites spécifiques aux ensembles de données sont imposées au téléchargement de données en vrac afin de maintenir la qualité du service.",
         "title": "Rechercher des données / Télécharger"
       },
       "title": "Accessibilité des données",
       "waf": {
-        "blurb": [
-          "Toutes les archives de fichiers de données qui ont été envoyées par les contributeurs en format CSV étendu sont disponibles sur ",
-          "https://woudc.org/archive/",
-          ", les utilisateurs peuvent les parcourir, les télécharger ou les intégrer à leurs flux de travaux.",
-          "Les ",
-          "données d'archives",
-          " statiques sont également disponibles dans le WAF au format CSV avec compression ZIP. Ces archives sont mis à jour hebdomadairement et offrent aux usagers une méthode pour télécharger le jeu de données entier au format CSV.",
-          "Veuillez consulter les ",
-          "instructions de WAF",
-          " pour plus de détails."
-        ],
+        "blurb": {
+          "how-to": "instructions de WAF",
+          "summary": "données d'archives",
+          "template": "Toutes les archives de fichiers de données qui ont été envoyées par les contributeurs en format CSV étendu sont disponibles sur {waf} les utilisateurs peuvent les parcourir, les télécharger ou les intégrer à leurs flux de travaux.\n\nLes {summary} statiques sont également disponibles dans le WAF au format CSV avec compression ZIP. Ces archives sont mis à jour hebdomadairement et offrent aux usagers une méthode pour télécharger le jeu de données entier au format CSV.\n\nVeuillez consulter les {how-to} pour plus de détails."
+        },
         "title": "Dossier accessible sur le web (WAF)"
       },
       "web": {
-        "blurb": [
-          "En plus des mécanismes d’accès aux données traditionnels, le WOUDC rend égalementdisponible ses archives par l’entremise de services web géospatiaux, se conformant ainsi aux normes internationales accessibles au public. Les services web sont des systèmes informatiques conçus pour prendre en charge des interactions machine à machine sur un réseau. Ils sont normalement utilisés dans un environnement informatique de type client/serveur accessible par des accès programmatiques, des outils connexes et des applications.",
-          "Les services web du WOUDC se conforment aux normes ouvertes ratifiées par l’",
-          "Open Geospatial Consortium",
-          " (OGC) et l’",
-          "International Organization for Standardization",
-          " (ISO) qui assurent l’interopérabilité des données, en facilitant ainsi la découverte, l’accessibilité, la visualisation et l’intégration. Les normes de l’OGC et de l’Organisation internationale de normalisation (ISO) jouent un rôle prépondérant dans l’",
-          "interopérabilité de l’Organisation météorologique mondiale",
-          " où elles font partie intégrante du ",
-          "système d’information de l’OMM",
-          " et sont prises en charge par de nombreuses sources libres grand public ou outils commerciaux."
-        ],
+        "blurb": {
+          "interoperability": "interopérabilité de l’Organisation météorologique mondiale",
+          "iso": "International Organization for Standardization",
+          "ogc": "Open Geospatial Consortium",
+          "template": "En plus des mécanismes d’accès aux données traditionnels, le WOUDC rend égalementdisponible ses archives par l’entremise de services web géospatiaux, se conformant ainsi aux normes internationales accessibles au public. Les services web sont des systèmes informatiques conçus pour prendre en charge des interactions machine à machine sur un réseau. Ils sont normalement utilisés dans un environnement informatique de type client/serveur accessible par des accès programmatiques, des outils connexes et des applications.\n\nLes services web du WOUDC se conforment aux normes ouvertes ratifiées par l’{ogc} (OGC) et l’{iso} (ISO) qui assurent l’interopérabilité des données, en facilitant ainsi la découverte, l’accessibilité, la visualisation et l’intégration. Les normes de l’OGC et de l’Organisation internationale de normalisation (ISO) jouent un rôle prépondérant dans l’{interoperability} où elles font partie intégrante du {wis} et sont prises en charge par de nombreuses sources libres grand public ou outils commerciaux.",
+          "wis": "système d’information de l’OMM"
+        },
         "table": {
           "links": [ "???" ],
           "title": "Ces services web de l’OGC sont mis à la disposition des utilisateurs afin d’assurer une accessibilité des données rapideet conforme aux normes :"
@@ -144,47 +117,34 @@
         "title": "Services web"
       },
       "wfs": {
-        "blurb": [
-          "Le ",
-          "Service de fonctionnalités web (WFS) de l’OGC",
-          " fournit une interface populaire pour permettre à l’utilisateur d’accéder aux données géospatiales. Le Service de fonctionnalités web (WFS) est habituellement utilisé pour effectuer des recherches personnalisées ou obtenir un accès brut aux fonctionnalités géospatiales. Le WFS du WOUDC permet l’accès à des données archivées dans divers formats comme le format CSV étendu, KML, CSV, GML, le fichier de formes ESRI, MapInfo, GeoJSON et NetCDF.",
-          "Le WFS a une limite côté serveur de 200000 entités au maximum, afin de pouvoir assurer la qualité du service et en garantir la disponibilité."
-        ],
+        "blurb": {
+          "template": "Le {wfs} fournit une interface populaire pour permettre à l’utilisateur d’accéder aux données géospatiales. Le Service de fonctionnalités web (WFS) est habituellement utilisé pour effectuer des recherches personnalisées ou obtenir un accès brut aux fonctionnalités géospatiales. Le WFS du WOUDC permet l’accès à des données archivées dans divers formats comme le format CSV étendu, KML, CSV, GML, le fichier de formes ESRI, MapInfo, GeoJSON et NetCDF.\n\nLe WFS a une limite côté serveur de 200000 entités au maximum, afin de pouvoir assurer la qualité du service et en garantir la disponibilité.",
+          "wfs": "Service de fonctionnalités web (WFS) de l’OGC"
+        },
         "note": {
-          "body": [
-            "Le WOUDC donne accès au WFS de l’OGC (versions 1.0.0 - 1.1.0) à ces différents endroits : ",
-            "https://geo.woudc.org/ows?service=WFS&version=1.1.0&request=GetCapabilities"
-          ],
+          "template": "Le WOUDC donne accès au WFS de l’OGC (versions 1.0.0 - 1.1.0) à ces différents endroits : {link}",
           "title": "Le WOUDC et le WFS de l’OGC"
         },
         "title": "Service de caractéristiques web (WFS)"
       },
       "wms": {
-        "blurb": [
-          "Le ",
-          "Service de cartes Web de l’OGC",
-          " fournit une interface populaire utilisée pour visualiser des couches de données géospatiales. Le WMS est souvent utilisé pour effectuer une visualisation simple sur le web ou sur une application SIG à l’aide des formats d’image adaptés pour une utilisation sur le web comme les formats PNG ou JPEG, par exemple."
-        ],
+        "blurb": {
+          "template": "Le {wms} fournit une interface populaire utilisée pour visualiser des couches de données géospatiales. Le WMS est souvent utilisé pour effectuer une visualisation simple sur le web ou sur une application SIG à l’aide des formats d’image adaptés pour une utilisation sur le web comme les formats PNG ou JPEG, par exemple.",
+          "wms": "Service de cartes Web de l’OGC"
+        },
         "note": {
-          "body": [
-            "Le WOUDC donne accès au WMS de l’OGC (versions 1.1.1 - 1.3.0) à cet endroit : ",
-            "https://geo.woudc.org/ows?service=WMS&version=1.3.0&request=GetCapabilities"
-          ],
+          "template": "Le WOUDC donne accès au WMS de l’OGC (versions 1.1.1 - 1.3.0) à cet endroit : {link}",
           "title": "Le WOUDC et le WMS de l’OGC"
         },
         "title": "Service de cartes web (WMS)"
       },
       "wps": {
-        "blurb": [
-          "Le ",
-          "Service de fonctionnalités web (WFS) de l’OGC",
-          " fournit une interface populaire pour permettre à l’utilisateur d’accéder aux données géospatiales. Le Service de fonctionnalités web (WFS) est habituellement utilisé pour effectuer des recherches personnalisées ou obtenir un accès brut aux fonctionnalités géospatiales. Le WFS du WOUDC permet l’accès à des données archivées dans divers formats comme le format CSV étendu, KML, CSV, GML, le fichier de formes ESRI, MapInfo, GeoJSON et NetCDF."
-        ],
+        "blurb": {
+          "template": "Le {wps} fournit une interface populaire pour permettre à l’utilisateur d’accéder aux données géospatiales. Le Service de fonctionnalités web (WFS) est habituellement utilisé pour effectuer des recherches personnalisées ou obtenir un accès brut aux fonctionnalités géospatiales. Le WFS du WOUDC permet l’accès à des données archivées dans divers formats comme le format CSV étendu, KML, CSV, GML, le fichier de formes ESRI, MapInfo, GeoJSON et NetCDF.",
+          "wps": "Service de fonctionnalités web (WFS) de l’OGC"
+        },
         "note": {
-          "body": [
-            "Le WOUDC fournit le WPS de l'OGC (version 1.0.0.0) au point d'extrémité suivant : ",
-            "https://geo.woudc.org/wps?service=WPS&version=1.0.0&request=GetCapabilities"
-          ],
+          "template": "Le WOUDC fournit le WPS de l'OGC (version 1.0.0.0) au point d'extrémité suivant : {link}",
           "title": "Le WOUDC et le WPS de l’OGC"
         },
         "title": "Service de traitement web (WPS)"
@@ -695,18 +655,16 @@
       "title": "Qu’est-ce que le WOUDC"
     },
     "policy": {
-      "blurb": [
-        "L’utilisation des données du WOUDC est régie par la ",
-        "politique sur les données de L’Organisation météorologique mondiale (OMM)",
-        " et la ",
-        "politique d’utilisation des données de la Veille de l’atmosphère du globe (VAG) de l’OMM"
-      ],
+      "blurb": {
+        "gaw": "politique d’utilisation des données de la Veille de l’atmosphère du globe (VAG) de l’OMM",
+        "template": "L’utilisation des données du WOUDC est régie par la {wmo} et la {gaw}.",
+        "wmo": "politique sur les données de L’Organisation météorologique mondiale (OMM)"
+      },
       "doi": {
-        "blurb": [
-          "WOUDC a enregistré ",
-          "DOIs",
-          " pour les données sur l’ozone et les rayons UV. Les identificateurs d’objets numériques (ION) sont des identificateurs permanents qui rendent les données de recherche accessibles et en permettent la citation. Ils facilitent l’accès aux données de recherche, la réutilisation et la vérification, et ainsi tirer profit du travail déjà réalisé, mener de nouvelles recherches et éviter la duplication du travail déjà fait."
-        ],
+        "blurb": {
+          "dois": "DOIs",
+          "template": "WOUDC a enregistré {dois} pour les données sur l’ozone et les rayons UV. Les identificateurs d’objets numériques (ION) sont des identificateurs permanents qui rendent les données de recherche accessibles et en permettent la citation. Ils facilitent l’accès aux données de recherche, la réutilisation et la vérification, et ainsi tirer profit du travail déjà réalisé, mener de nouvelles recherches et éviter la duplication du travail déjà fait."
+        },
         "note1": {
           "items": [
             "Ozone: doi:10.14287/10000001",
@@ -750,10 +708,10 @@
       },
       "publishing": {
         "blurb1": "Lors de la publication de données extraites du WOUDC, vous devezindiquer les contributeurs qui ont fourni les données, ainsi que la source des données et le WOUDC, en utilisant la citation appropriée comme indiqué dans l’exemple suivant.",
-        "blurb2": [
-          "Pour la liste complète de tous les contributeurs, voir la ",
-          "liste des contributeurs"
-        ],
+        "blurb2": {
+          "contributors": "liste des contributeurs",
+          "template": "Pour la liste complète de tous les contributeurs, voir la {contributors}."
+        },
         "note1": {
           "body": "JMA, & NASA-WFF. Organisation météorologique mondiale-Programme de Veille de l’atmosphère du globe (OMM-VAG)/Centre mondial des données sur l’ozone et le rayonnement ultraviolet (WOUDC) [Données]. Page consultée le 24 octobre 2013 : https://woudc.org. doi:10.14287/10000001",
           "title": "Exemple (1) : Citation des données provenant (contribuées par) la Japan Meteorological Agency (JMA) et la NASA (NASA-WFF) et extraites du site du WOUDC"
@@ -769,11 +727,10 @@
       },
       "title": "Politique d’utilisation des données",
       "wmo": {
-        "blurb": [
-          "L’OMM facilite l’échange gratuit et sans restriction, en temps réel ou quasi réel, de données, d’informations, de produits et de services propres à renforcer la sécurité des populations, le bien-être économique et la protection de l’environnement.",
-          "Résolution 40 (Cg-XII)",
-          " : Politique et pratique adoptée par l’OMM pour l’échange de données et de produits météorologiques et connexes, y compris ses principes directeurs applicables aux relations entre partenaires en matière de commercialisation des services météorologiques."
-        ],
+        "blurb": {
+          "link": "Résolution 40 (Cg-XII)",
+          "template": "L’OMM facilite l’échange gratuit et sans restriction, en temps réel ou quasi réel, de données, d’informations, de produits et de services propres à renforcer la sécurité des populations, le bien-être économique et la protection de l’environnement.\n\n{link} : Politique et pratique adoptée par l’OMM pour l’échange de données et de produits météorologiques et connexes, y compris ses principes directeurs applicables aux relations entre partenaires en matière de commercialisation des services météorologiques."
+        },
         "title": "Politique des données de l’Organisation météorologique mondiale"
       }
     },
@@ -843,54 +800,28 @@
         "Format/Codage",
         "Services web"
       ],
-      "links": [
-        {
-          "resource": "Métadonnées de découverte",
-          "formats": [
-            "ISO 19115 WMO Core Metadata Profile"
-          ],
-          "services": [
-            "OGC:CSW",
-            "OAI-PMH",
-            "OpenSearch"
-          ]
+      "links": {
+        "resources": [
+          "Métadonnées de découverte",
+          "Station de métadonnées",
+          "Métadonnées des instruments",
+          "Observations"
+        ],
+        "formats": {
+          "csv": "CSV",
+          "geojson": "GeoJSON",
+          "gml": "OGC:GML",
+          "iso": "ISO 19115 WMO Core Metadata Profile",
+          "wigos": "WIGOS"
         },
-        {
-          "resource": "Station de métadonnées",
-          "formats": [
-            "OGC:GML",
-            "WIGOS"
-          ],
-          "services": [
-            "OGC:WMS",
-            "OGC:WFS"
-          ]
-        },
-        {
-          "resource": "Métadonnées des instruments",
-          "formats": [
-            "OGC:GML",
-            "WIGOS"
-          ],
-          "services": [
-            "OGC:WMS",
-            "OGC:WFS"
-          ]
-        },
-        {
-          "resource": "Observations",
-          "formats": [
-            "CSV",
-            "GeoJSON",
-            "OGC:GML",
-            "WIGOS"
-          ],
-          "services": [
-            "OGC:WMS",
-            "OGC:WFS"
-          ]
+        "services": {
+          "csw": "OGC:CSW",
+          "opensearch": "OpenSearch",
+          "pmh": "OAI-PMH",
+          "wfs": "OGC:WFS",
+          "wms": "OGC:WMS"
         }
-      ],
+      },
       "title": "Normes"
     }
   },

--- a/pages/about/dataaccess.vue
+++ b/pages/about/dataaccess.vue
@@ -1,339 +1,297 @@
 <template>
   <div>
     <h1>{{ $t('about.access.title') }}</h1>
-    <v-card id="table-of-contents">
+    <v-card id="contents-table">
       <v-card-title>
         {{ $t('about.access.contents.title') }}
       </v-card-title>
-      <v-data-table
-        :headers="linkHeaders"
-        :items="contents"
-        hide-default-header
-        hide-default-footer
-      >
-        <template v-slot:item.link="section">
-          <td>
-            <woudc-link :link="selfLink(section.item)" />
-            <ul v-if="section.item.children !== undefined">
-              <li v-for="(link, i) in section.item.children" :key="i">
-                <woudc-link :link="selfLink(link)" />
+      <v-list id="contents-body">
+        <div v-for="(section, i) in contents" :key="i">
+          <v-divider v-if="i !== 0" />
+          <v-list-item>
+            <nuxt-link :to="'#' + section.selector" v-text="section.text" />
+          </v-list-item>
+          <v-list-item v-if="section.children !== undefined">
+            <ul>
+              <li v-for="(child, j) in section.children" :key="j">
+                <nuxt-link :to="'#' + child.selector" v-text="child.text" />
               </li>
             </ul>
-          </td>
-        </template>
-      </v-data-table>
+          </v-list-item>
+        </div>
+      </v-list>
     </v-card>
-    <woudc-blurb :items="mainBlurb" />
-    <woudc-note
-      :title="$t('about.access.note1.title')"
-      :body="note1Body"
-      maxwidth="68%"
-    />
-    <woudc-note
-      :title="$t('about.access.note2.title')"
-      :body="note2Body"
-      maxwidth="68%"
-    />
+    <i18n class="newlines" path="about.access.blurb.template" tag="p">
+      <template v-slot:contact>
+        <nuxt-link :to="localePath('contact')" v-text="$t('about.access.blurb.contact')" />
+      </template>
+    </i18n>
+    <v-card class="woudc-note" tile max-width="68%" min-width="0px">
+      <v-card-title v-text="$t('about.access.note1.title')" />
+      <v-card-text>
+        <i18n path="about.access.note1.body.template" tag="p">
+          <template v-slot:policy>
+            <nuxt-link
+              :to="localePath('about-datapolicy')"
+              v-text="$t('about.access.note1.body.policy')"
+            />
+          </template>
+        </i18n>
+      </v-card-text>
+    </v-card>
+    <v-card class="woudc-note" tile max-width="68%" min-width="0px">
+      <v-card-title v-text="$t('about.access.note2.title')" />
+      <v-card-text>
+        <i18n path="about.access.note2.body.template" tag="p">
+          <template v-slot:stations>
+            <nuxt-link
+              :to="localePath('data-stations')"
+              v-text="$t('about.access.note2.body.stations')"
+            />
+          </template>
+        </i18n>
+      </v-card-text>
+    </v-card>
     <div id="data-search-section">
       <h2>{{ $t('about.access.search.title') }}</h2>
-      <woudc-blurb :items="searchBlurb" />
-      <woudc-note :body="$t('about.access.search.note')" maxwidth="68%" />
+      <i18n class="newlines" path="about.access.search.blurb.template" tag="p">
+        <template v-slot:search>
+          <nuxt-link :to="localePath('data-explore')" v-text="$t('about.access.search.blurb.search')" />
+        </template>
+        <template v-slot:how-to>
+          <a :href="searchHelpURL" target="_blank" v-text="$t('about.access.search.blurb.how-to')" />
+        </template>
+      </i18n>
+      <v-card class="woudc-note" tile max-width="68%" min-width="0px">
+        <v-card-text>
+          {{ $t('about.access.search.note') }}
+        </v-card-text>
+      </v-card>
     </div>
     <div id="waf-section">
       <h2>{{ $t('about.access.waf.title') }}</h2>
-      <woudc-blurb :items="wafBlurb" />
+      <i18n class="newlines" path="about.access.waf.blurb.template" tag="p">
+        <template v-slot:waf>
+          <a :href="wafURL" target="_blank" v-text="$t('wafFull')" />
+        </template>
+        <template v-slot:summary>
+          <a :href="wafSummaryURL" target="_blank" v-text="$t('about.access.waf.blurb.summary')" />
+        </template>
+        <template v-slot:how-to>
+          <a :href="wafGuideURL" target="_blank" v-text="$t('about.access.waf.blurb.how-to')" />
+        </template>
+      </i18n>
     </div>
     <div id="web-services-section">
       <h2>{{ $t('about.access.web.title') }}</h2>
-      <woudc-blurb :items="webBlurb" />
-      <woudc-note
-        :title="$t('about.access.web.table.title')"
-        body="That font size is too big. Also the colour is wrong."
-      />
+      <i18n class="newlines" path="about.access.web.blurb.template" tag="p">
+        <template v-slot:ogc>
+          <a :href="ogcURL" target="_blank" v-text="$t('about.access.web.blurb.ogc')" />
+        </template>
+        <template v-slot:iso>
+          <a :href="isoURL" target="_blank" v-text="$t('about.access.web.blurb.iso')" />
+        </template>
+        <template v-slot:interoperability>
+          <a :href="interoperabilityURL" target="_blank" v-text="$t('about.access.web.blurb.interoperability')" />
+        </template>
+        <template v-slot:wis>
+          <a :href="wisURL" target="_blank" v-text="$t('about.access.web.blurb.wis')" />
+        </template>
+      </i18n>
+      <v-card class="woudc-note" tile min-width="0px">
+        <v-card-title v-text="$t('about.access.web.table.title')" />
+        <v-card-text>
+          <p>That font size is too big. Also the colour is wrong.</p>
+        </v-card-text>
+      </v-card>
       <div id="csw-subsection">
         <h2>{{ '1. ' + $t('about.access.csw.title') }}</h2>
-        <woudc-blurb :items="cswBlurb" />
-        <woudc-note
-          :title="$t('about.access.csw.note.title')"
-          :body="cswNote"
-        />
+        <i18n path="about.access.csw.blurb.template" tag="p">
+          <template v-slot:ogc>
+            <a :href="ogcStandardsURL" target="_blank" v-text="$t('about.access.csw.blurb.ogc')" />
+          </template>
+        </i18n>
+        <v-card class="woudc-note" tile min-width="0px">
+          <v-card-title v-text="$t('about.access.csw.note.title')" />
+          <v-card-text>
+            <i18n path="about.access.csw.note.template" tag="p">
+              <template v-slot:link>
+                <a :href="cswURL" target="_blank" v-text="cswURL" />
+              </template>
+            </i18n>
+          </v-card-text>
+        </v-card>
       </div>
       <div id="wms-subsection">
         <h2>{{ '2. ' + $t('about.access.wms.title') }}</h2>
-        <woudc-blurb :items="wmsBlurb" />
-        <woudc-note
-          :title="$t('about.access.wms.note.title')"
-          :body="wmsNote"
-        />
+        <i18n path="about.access.wms.blurb.template" tag="p">
+          <template v-slot:wms>
+            <a href="" target="_blank" v-text="$t('about.access.wms.blurb.wms')" />
+          </template>
+        </i18n>
+        <v-card class="woudc-note" tile min-width="0px">
+          <v-card-title v-text="$t('about.access.wms.note.title')" />
+          <v-card-text>
+            <i18n path="about.access.wms.note.template" tag="p">
+              <template v-slot:link>
+                <a :href="wmsURL" target="_blank" v-text="wmsURL" />
+              </template>
+            </i18n>
+          </v-card-text>
+        </v-card>
       </div>
       <div id="wfs-subsection">
         <h2>{{ '3. ' + $t('about.access.wfs.title') }}</h2>
-        <woudc-blurb :items="wfsBlurb" />
-        <woudc-note
-          :title="$t('about.access.wfs.note.title')"
-          :body="wfsNote"
-        />
+        <i18n path="about.access.wfs.blurb.template" tag="p">
+          <template v-slot:wfs>
+            <a href="" target="_blank" v-text="$t('about.access.wfs.blurb.wfs')" />
+          </template>
+        </i18n>
+        <v-card class="woudc-note" tile min-width="0px">
+          <v-card-title v-text="$t('about.access.wfs.note.title')" />
+          <v-card-text>
+            <i18n path="about.access.wfs.note.template" tag="p">
+              <template v-slot:link>
+                <a :href="wfsURL" target="_blank" v-text="wfsURL" />
+              </template>
+            </i18n>
+          </v-card-text>
+        </v-card>
       </div>
       <div id="wps-section">
         <h2>{{ '4. ' + $t('about.access.wps.title') }}</h2>
-        <woudc-blurb :items="wpsBlurb" />
-        <woudc-note
-          :title="$t('about.access.wps.note.title')"
-          :body="wpsNote"
-        />
+        <i18n path="about.access.wps.blurb.template" tag="p">
+          <template v-slot:wps>
+            <a href="" target="_blank" v-text="$t('about.access.wps.blurb.wps')" />
+          </template>
+        </i18n>
+        <v-card class="woudc-note" tile min-width="0px">
+          <v-card-title v-text="$t('about.access.wps.note.title')" />
+          <v-card-text>
+            <i18n path="about.access.wps.note.template" tag="p">
+              <template v-slot:link>
+                <a :href="wpsURL" target="_blank" v-text="wpsURL" />
+              </template>
+            </i18n>
+          </v-card-text>
+        </v-card>
       </div>
     </div>
     <div id="definitions-service-section">
       <h2>{{ $t('about.access.definitions.title') }}</h2>
       <p>{{ $t('about.access.definitions.blurb') }}</p>
-      <woudc-note
-        :title="$t('about.access.definitions.note.title')"
-        :body="definitionsNote"
-      />
+      <v-card class="woudc-note" tile min-width="0px">
+        <v-card-title v-text="$t('about.access.definitions.note.title')" />
+        <v-card-text>
+          <i18n path="about.access.definitions.note.template" tag="p">
+            <template v-slot:link>
+              <a :href="definitionsURL" target="_blank" v-text="definitionsURL" />
+            </template>
+          </i18n>
+        </v-card-text>
+      </v-card>
     </div>
     <div id="iso-catalogue-section">
       <h2>{{ $t('about.access.iso.title') }}</h2>
       <p>{{ $t('about.access.iso.blurb1') }}</p>
-      <woudc-note
-        :title="$t('about.access.iso.note.title')"
-        :body="isoNote"
-      />
-      <woudc-blurb :items="isoBlurb2" />
+      <v-card class="woudc-note" tile min-width="0px">
+        <v-card-title v-text="$t('about.access.iso.note.title')" />
+        <v-card-text>
+          <i18n path="about.access.iso.note.template" tag="p">
+            <template v-slot:link>
+              <a :href="isoURL" target="_blank" v-text="isoURL" />
+            </template>
+          </i18n>
+        </v-card-text>
+      </v-card>
+      <i18n path="about.access.iso.blurb2.template" tag="p">
+        <template v-slot:how-to>
+          <a href="" target="_blank" v-text="$t('about.access.iso.blurb2.how-to')" />
+        </template>
+      </i18n>
     </div>
     <div id="examples-section">
       <h2>{{ $t('about.access.examples.title') }}</h2>
-      <woudc-blurb :items="examplesBlurb" />
-      <v-data-table
-        :headers="linkHeaders"
-        :items="examples"
-        hide-default-header
-        hide-default-footer
-        class="elevation-1"
-      >
-        <template v-slot:item.link="props">
-          <a :href="props.item.to">{{ props.item.text }}</a>
-          : {{ props.item.description }}
+      <i18n path="about.access.examples.blurb.template" tag="p">
+        <template v-slot:github>
+          <a :href="githubURL" target="_blank" v-text="$t('about.access.examples.blurb.github')" />
         </template>
-      </v-data-table>
+      </i18n>
+      <v-card>
+        <v-list id="example-list" dense>
+          <v-list-item>
+            <a :href="exampleLinks[0]" target="_blank" v-text="exampleNames[0]" /> : {{ $t('about.access.examples.links[0]') }}
+          </v-list-item>
+          <v-divider />
+          <v-list-item>
+            <a :href="exampleLinks[1]" target="_blank" v-text="exampleNames[1]" /> : {{ $t('about.access.examples.links[1]') }}
+          </v-list-item>
+        </v-list>
+      </v-card>
     </div>
   </div>
 </template>
 
 <script>
-import WoudcLink from '~/components/WoudcLink'
-import WoudcBlurb from '~/components/WoudcBlurb'
-import WoudcNote from '~/components/WoudcNote'
-
-const emptyHeader = {
-  text: '',
-  align: 'left',
-  sortable: false,
-  value: 'link'
-}
-
-const examplesLinks = [
-  {
-    text: 'pywoudc',
-    to: 'https://github.com/woudc/pywoudc'
-  },
-  {
-    text: 'notebooks',
-    to: 'https://github.com/woudc/woudc/tree/master/notebooks'
-  }
-]
-
 export default {
-  components: {
-    'woudc-link': WoudcLink,
-    'woudc-blurb': WoudcBlurb,
-    'woudc-note': WoudcNote
-  },
   data() {
     return {
-      contents: [
-        {
-          text: this.$t('about.access.contents.links[0]'),
-          selector: '#data-search-section'
-        },
-        {
-          text: this.$t('about.access.contents.links[1]'),
-          selector: 'waf-section'
-        },
-        {
-          text: this.$t('about.access.contents.links[2]'),
-          selector: 'web-services-section',
-          children: [
-            {
-              text: this.$t('about.access.contents.links[3]'),
-              selector: '#csw-subsection'
-            },
-            {
-              text: this.$t('about.access.contents.links[4]'),
-              selector: '#wms-subsection'
-            },
-            {
-              text: this.$t('about.access.contents.links[5]'),
-              selector: '#wfs-subsection'
-            },
-            {
-              text: this.$t('about.access.contents.links[6]'),
-              selector: '#wps-subsection'
-            }
-          ]
-        },
-        {
-          text: this.$t('about.access.contents.links[7]'),
-          selector: '#definitions-service-section'
-        },
-        {
-          text: this.$t('about.access.contents.links[8]'),
-          selector: '#iso-catalogue-section'
-        },
-        {
-          text: this.$t('about.access.contents.links[9]'),
-          selector: '#examples-section'
-        }
+      cswURL: 'https://geo.woudc.org/csw?service=CSW&version=2.0.2&request=GetCapabilities',
+      definitionsURL: 'https://geo.woudc.org/def',
+      githubURL: 'https://github.com/woudc',
+      interoperabilityURL: 'https://www.wmo.int/pages/prog/www/WIS/documents/MOAWMO_OGC.pdf',
+      isoURL: 'https://geo.woudc.org/codelists.xml',
+      ogcStandardsURL: 'https://opengeospatial.org/standards/cat',
+      ogcURL: 'https://opengeospatial.org/',
+      searchHelpURL: 'https://github.com/woudc/woudc/wiki/DataSearchDownloadHowto',
+      wafURL: 'https://woudc.org/archive/',
+      wafGuideURL: 'https://github.com/woudc/woudc/wiki/WAFHowto',
+      wafSummaryURL: 'https://woudc.org/archive/Summaries/dataset-snapshots',
+      wfsURL: 'https://geo.woudc.org/ows?service=WFS&version=1.1.0&request=GetCapabilities',
+      wisURL: 'https://www.wmo.int/pages/prog/www/WIS/',
+      wmsURL: 'https://geo.woudc.org/ows?service=WMS&version=1.3.0&request=GetCapabilities',
+      wpsURL: 'https://geo.woudc.org/wps?service=WPS&version=1.0.0&request=GetCapabilities',
+      contentsSelectors: [
+        'data-search-section',
+        'waf-section',
+        'web-services-section',
+        'csw-subsection',
+        'wms-subsection',
+        'wfs-subsection',
+        'wps-subsection',
+        'definitions-service-section',
+        'iso-catalogue-section',
+        'examples-section'
       ],
-      cswBlurb: [
-        { text: this.$t('about.access.csw.blurb[0]') },
-        { link: { to: 'https://www.opengeospatial.org/standards/cat', type: 'external', text: this.$t('about.access.csw.blurb[1]') } },
-        { text: this.$t('about.access.csw.blurb[2]') }
-      ],
-      cswNote: [
-        { text: this.$t('about.access.csw.note.body[0]') },
-        { link: { to: 'https://geo.woudc.org/csw?service=CSW&version=2.0.2&request=GetCapabilities', type: 'external', text: this.$t('about.access.csw.note.body[1]') } }
-      ],
-      definitionsNote: [
-        { text: this.$t('about.access.definitions.note.body[0]') },
-        { link: { to: 'https://geo.woudc.org/def', type: 'external', text: this.$t('about.access.definitions.note.body[1]') } }
-      ],
-      examples: [...examplesLinks.keys()].map((index) => {
-        return {
-          text: examplesLinks[index].text,
-          to: examplesLinks[index].to,
-          description: this.$t('about.access.examples.links[' + index  + ']')
-        }
-      }),
-      examplesBlurb: [
-        { text: this.$t('about.access.examples.blurb[0]') },
-        { link: { to: 'https://github.com/woudc', type: 'external', text: this.$t('about.access.examples.blurb[1]') } },
-        { text: this.$t('about.access.examples.blurb[2]') },
-      ],
-      isoBlurb2: [
-        { text: this.$t('about.access.iso.blurb2[0]') },
-        { link: { to: 'https://github.com/woudc/woudc/wiki/WebServicesHowto', type: 'external', text: this.$t('about.access.iso.blurb2[1]') } },
-        { text: this.$t('about.access.iso.blurb2[2]') }
-      ],
-      isoNote: [
-        { text: this.$t('about.access.iso.note.body[0]') },
-        { link: { to: 'https://geo.woudc.org/codelists.xml', type: 'external', text: this.$t('about.access.iso.note.body[1]') } }
-      ],
-      mainBlurb: [
-        { text: this.$t('about.access.blurb[0]') },
-        { newlines: 2 },
-        { text: this.$t('about.access.blurb[1]') },
-        { link: { to: 'contact', text: this.$t('about.access.blurb[2]') } },
-        { text: '.' }
-      ],
-      note1Body: [
-        { text: this.$t('about.access.note1.body[0]') },
-        { link: { to: 'about-datapolicy', text: this.$t('about.access.note1.body[1]') } },
-        { text: '.' }
-      ],
-      note2Body: [
-        { text: this.$t('about.access.note2.body[0]') },
-        { link: { to: 'about-datapolicy', text: this.$t('about.access.note2.body[1]') } },
-        { text: this.$t('about.access.note2.body[2]') }
-      ],
-      linkHeaders: [
-        emptyHeader
-      ],
-      searchBlurb: [
-        { text: this.$t('about.access.search.blurb[0]') },
-        { link: { to: 'data-explore', text: this.$t('about.access.search.blurb[1]') } },
-        { text: this.$t('about.access.search.blurb[2]') },
-        { newlines: 2 },
-        { text: this.$t('about.access.search.blurb[3]') },
-        { link: { to: 'https://github.com/woudc/woudc/wiki/DataSearchDownloadHowto', type: 'external', text: this.$t('about.access.search.blurb[4]') } },
-        { text: this.$t('about.access.search.blurb[5]') }
-      ],
-      wafBlurb: [
-        { text: this.$t('about.access.waf.blurb[0]') },
-        { link: { to: 'https://woudc.org/archive/', type: 'external', text: this.$t('about.access.waf.blurb[1]') } },
-        { text: this.$t('about.access.waf.blurb[2]') },
-        { newlines: 2 },
-        { text: this.$t('about.access.waf.blurb[3]') },
-        { link: { to: 'https://woudc.org/archive/Summaries/dataset-snapshots', type: 'external', text: this.$t('about.access.waf.blurb[4]') } },
-        { text: this.$t('about.access.waf.blurb[5]') },
-        { newlines: 2 },
-        { text: this.$t('about.access.waf.blurb[6]') },
-        { link: { to: 'https://github.com/woudc/woudc/wiki/WAFHowto', type: 'external', text: this.$t('about.access.waf.blurb[7]') } },
-        { text: this.$t('about.access.waf.blurb[8]') }
-      ],
-      webBlurb: [
-        { text: this.$t('about.access.web.blurb[0]') },
-        { newlines: 2 },
-        { text: this.$t('about.access.web.blurb[1]') },
-        { link: { to: 'https://opengeospatial.org/', type: 'external', text: this.$t('about.access.web.blurb[2]') } },
-        { text: this.$t('about.access.web.blurb[3]') },
-        { link: { to: 'https://www.isotc211.org/', type: 'external', text: this.$t('about.access.web.blurb[4]') } },
-        { text: this.$t('about.access.web.blurb[5]') },
-        { link: { to: 'https://www.wmo.int/pages/prog/www/WIS/documents/MOAWMO_OGC.pdf', type: 'external', text: this.$t('about.access.web.blurb[6]') } },
-        { text: this.$t('about.access.web.blurb[7]') },
-        { link: { to: 'https://www.wmo.int/pages/prog/www/WIS/', type: 'external', text: this.$t('about.access.web.blurb[8]') } },
-        { text: this.$t('about.access.web.blurb[9]') }
-      ],
-      wfsBlurb: [
-        { text: this.$t('about.access.wfs.blurb[0]') },
-        { link: { to: 'https://www.opengeospatial.org/standards/wfs', type: 'external', text: this.$t('about.access.wfs.blurb[1]') } },
-        { text: this.$t('about.access.wfs.blurb[2]') }
-      ],
-      wfsNote: [
-        { text: this.$t('about.access.wfs.note.body[0]') },
-        { link: { to: 'https://geo.woudc.org/ows?service=WFS&version=1.1.0&request=GetCapabilities', type: 'external', text: this.$t('about.access.wfs.note.body[1]') } }
-      ],
-      wmsBlurb: [
-        { text: this.$t('about.access.wms.blurb[0]') },
-        { link: { to: 'https://www.opengeospatial.org/standards/wms', type: 'external', text: this.$t('about.access.wms.blurb[1]') } },
-        { text: this.$t('about.access.wms.blurb[2]') }
-      ],
-      wmsNote: [
-        { text: this.$t('about.access.wms.note.body[0]') },
-        { link: { to: 'https://geo.woudc.org/ows?service=WMS&version=1.3.0&request=GetCapabilities', type: 'external', text: this.$t('about.access.wms.note.body[1]') } }
-      ],
-      wpsBlurb: [
-        { text: this.$t('about.access.wps.blurb[0]') },
-        { link: { to: 'https://www.opengeospatial.org/standards/wps', type: 'external', text: this.$t('about.access.wps.blurb[1]') } },
-        { text: this.$t('about.access.wps.blurb[2]') }
-      ],
-      wpsNote: [
-        { text: this.$t('about.access.wps.note.body[0]') },
-        { link: { to: 'https://geo.woudc.org/wps?service=WPS&version=1.0.0&request=GetCapabilities', type: 'external', text: this.$t('about.access.wps.note.body[1]') } }
+      exampleNames: [ 'pywoudc', 'notebooks' ],
+      exampleLinks: [
+        'https://github.com/woudc/pywoudc',
+        'https://github.com/woudc/woudc/tree/master/notebooks'
       ]
     }
   },
   computed: {
-    examplesLinks() {
-      const links = []
-      for (let i = 0; this.$t('examples-links')[i] !== undefined; i++) {
-        links.push(this.$t('examples-links')[i])
-      }
-      return links
+    contents() {
+      const head = [0, 1, 2].map(this.prepareContentsLink)
+      const subsections = [3, 4, 5, 6].map(this.prepareContentsLink)
+      const tail = [7, 8, 9].map(this.prepareContentsLink)
+
+      head[2].children = subsections
+      return head.concat(tail)
     }
   },
   methods: {
-    selfLink(props) {
+    prepareContentsLink(index) {
       return {
-        text: props.text,
-        to: 'about-dataaccess',
-        selector: props.selector
+        text: this.$t('about.access.contents.links[' + index + ']'),
+        selector: this.contentsSelectors[index]
       }
     }
   },
   nuxtI18n: {
     paths: {
-      en: '/data-access',
-      fr: '/data-access-fr'
+      en: '/about/data-access',
+      fr: '/apropos/data-access-fr'
     }
   }
 }
@@ -345,7 +303,7 @@ export default {
   color: steelblue;
 }
 
-#table-of-contents {
+#contents-table {
   float: right;
   max-width: 30%;
 
@@ -353,5 +311,19 @@ export default {
 
   color: white;
   background-color: royalblue;
+}
+
+#contents-body {
+  padding: 0px;
+  font-size: 14px;
+}
+
+#contents-body ul {
+  margin-bottom: 16px;
+}
+
+#example-list {
+  padding: 0px;
+  font-size: 14px;
 }
 </style>

--- a/pages/about/datapolicy.vue
+++ b/pages/about/datapolicy.vue
@@ -1,17 +1,32 @@
 <template>
   <v-layout justify-center column align-content-center>
     <h1>{{ $t('about.policy.title') }}</h1>
-    <woudc-blurb :items="mainBlurb" />
-    <h2>{{ $t('about.policy.wmo.title') }}</h2>
-    <woudc-blurb :items="wmoBlurb" />
-    <h2>{{ $t('about.policy.gaw.title') }}</h2>
-    <p>{{ gawBlurb }}</p>
-    <woudc-note
-      :title="$t('about.policy.gaw.note.title')"
-      :body="$t('about.policy.gaw.note.body')"
-    />
-    <h2>{{ $t('about.policy.doi.title') }}</h2>
-    <woudc-blurb :items="doiBlurb" />
+    <i18n path="about.policy.blurb.template" tag="p">
+      <template v-slot:wmo>
+        <a :href="wmoURL" target="_blank" v-text="$t('about.policy.blurb.wmo')" />
+      </template>
+      <template v-slot:gaw>
+        <a :href="gawURL" target="_blank" v-text="$t('about.policy.blurb.gaw')" />
+      </template>
+    </i18n>
+    <h2 v-text="$t('about.policy.wmo.title')" />
+    <i18n class="newlines" path="about.policy.wmo.blurb.template" tag="p">
+      <template v-slot:link>
+        <a :href="resolution40" target="_blank" v-text="$t('about.policy.wmo.blurb.link')" />
+      </template>
+    </i18n>
+    <h2 v-text="$t('about.policy.gaw.title')" />
+    <p v-text="$t('about.policy.gaw.blurb')" />
+    <v-card class="woudc-note" tile min-width="0px">
+      <v-card-title v-text="$t('about.policy.gaw.note.title')" />
+      <v-card-text v-text="$t('about.policy.gaw.note.body')" />
+    </v-card>
+    <h2 v-text="$t('about.policy.doi.title')" />
+    <i18n path="about.policy.doi.blurb.template" tag="p">
+      <template v-slot:dois>
+        <a :href="doisURL" target="_blank" v-text="$t('about.policy.doi.blurb.dois')" />
+      </template>
+    </i18n>
     <v-card>
       <v-card-title class="card">
         {{ $t('about.policy.doi.note1.title') }}
@@ -25,9 +40,7 @@
       </v-card-text>
     </v-card>
     <v-card>
-      <v-card-title class="card">
-        {{ $t('about.policy.doi.note2.title') }}
-      </v-card-title>
+      <v-card-title class="card" v-text="$t('about.policy.doi.note2.title')" />
       <v-card-text>
         <ul>
           <li v-for="text in $t('about.policy.doi.note2.items')" :key="text">
@@ -36,20 +49,14 @@
         </ul>
       </v-card-text>
     </v-card>
-    <h2>{{ $t('about.policy.publishing.title') }}</h2>
-    <p>{{ publishingBlurb1 }}</p>
+    <h2 v-text="$t('about.policy.publishing.title')" />
+    <p v-text="$t('about.policy.publishing.blurb1')" />
     <v-card>
-      <v-card-title class="card">
-        {{ $t('about.policy.publishing.note1.title') }}
-      </v-card-title>
-      <v-card-text>
-        {{ $t('about.policy.publishing.note1.body') }}
-      </v-card-text>
+      <v-card-title class="card" v-text="$t('about.policy.publishing.note1.title')" />
+      <v-card-text v-text="$t('about.policy.publishing.note1.body')" />
     </v-card>
     <v-card>
-      <v-card-title class="card">
-        {{ $t('about.policy.publishing.note2.title') }}
-      </v-card-title>
+      <v-card-title class="card" v-text="$t('about.policy.publishing.note2.title')" />
       <v-card-text>
         <ol>
           <li v-for="text in $t('about.policy.publishing.note2.items')" :key="text">
@@ -58,63 +65,34 @@
         </ol>
       </v-card-text>
     </v-card>
-    <woudc-blurb :items="publishingBlurb2" />
-    <h2>{{ $t('about.policy.products.title') }}</h2>
-    <p>{{ productsBlurb }}</p>
+    <i18n path="about.policy.publishing.blurb2.template" tag="p">
+      <template v-slot:contributors>
+        <nuxt-link :to="localePath('contributors')" v-text="$t('about.policy.publishing.blurb2.contributors')" />
+      </template>
+    </i18n>
+    <h2 v-text="$t('about.policy.products.title')" />
+    <p v-text="$t('about.policy.products.blurb')" />
     <v-card>
-      <v-card-title class="card">
-        {{ $t('about.policy.products.note.title') }}
-      </v-card-title>
-      <v-card-text>
-        {{ $t('about.policy.products.note.body') }}
-      </v-card-text>
+      <v-card-title class="card" v-text="$t('about.policy.products.note.title')" />
+      <v-card-text v-text="$t('about.policy.products.note.body')" />
     </v-card>
   </v-layout>
 </template>
 
 <script>
-import WoudcBlurb from '~/components/WoudcBlurb'
-import WoudcNote from '~/components/WoudcNote'
-
 export default {
-  components: {
-    'woudc-blurb': WoudcBlurb,
-    'woudc-note': WoudcNote
-  },
   data() {
     return {
-      mainBlurb: [
-        { text: this.$t('about.policy.blurb[0]') },
-        { link: { to: 'https://www.wmo.int/pages/about/exchangingdata_en.html', type: 'external', text: this.$t('about.policy.blurb[1]') } },
-        { text: this.$t('about.policy.blurb[2]') },
-        { link: { to: 'https://gawsis.meteoswiss.ch/GAWSIS/index.html#/faq', type: 'external', text: this.$t('about.policy.blurb[3]') } },
-        { text: '.' }
-      ],
-      doiBlurb: [
-        { text: this.$t('about.policy.doi.blurb[0]') },
-        { link: { to: 'https://en.wikipedia.org/wiki/Digital_object_identifier', type: 'external', text: this.$t('about.policy.doi.blurb[1]') } },
-        { text: this.$t('about.policy.doi.blurb[2]') }
-      ],
-      gawBlurb: this.$t('about.policy.gaw.blurb'),
-      productsBlurb: this.$t('about.policy.products.blurb'),
-      publishingBlurb1: this.$t('about.policy.publishing.blurb1'),
-      publishingBlurb2: [
-        { text: this.$t('about.policy.publishing.blurb2[0]') },
-        { link: { to: 'contributors', text: this.$t('about.policy.publishing.blurb2[1]') } },
-        { text: '.' }
-      ],
-      wmoBlurb: [
-        { text: this.$t('about.policy.wmo.blurb[0]') },
-        { newlines: 2 },
-        { link: { to: 'https://www.wmo.int/pages/about/Resolution40_en.html', type: 'external', text: this.$t('about.policy.wmo.blurb[1]') } },
-        { text: this.$t('about.policy.wmo.blurb[0]') }
-      ],
+      doisURL: 'https://en.wikipedia.org/wiki/Digital_object_identifier',
+      gawURL: 'https://gawsis.meteoswiss.ch/GAWSIS/index.html#/faq',
+      resolution40: 'https://www.wmo.int/pages/about/Resolution40_en.html',
+      wmoURL: 'https://www.wmo.int/pages/about/exchangingdata_en.html'
     }
   },
   nuxtI18n: {
     paths: {
-      en: '/data-policy',
-      fr: '/politique-donnees'
+      en: '/about/data-policy',
+      fr: '/apropos/politique-donnees'
     }
   }
 }

--- a/pages/about/dataquality.vue
+++ b/pages/about/dataquality.vue
@@ -1,83 +1,76 @@
 <template>
   <v-layout justify-center column align-content-center>
-    <h1>{{ $t('about.quality.title') }}</h1>
-    <p>{{ $t('about.quality.blurb') }}</p>
-    <h2>{{ $t('gawFull') }}</h2>
-    <woudc-blurb :items="gawBlurb" />
-    <h2>{{ $t('about.quality.sag.title') }}</h2>
-    <woudc-blurb :items="sagBlurb" />
+    <h1 v-text="$t('about.quality.title')" />
+    <p v-text="$t('about.quality.blurb')" />
+    <h2 v-text="$t('gawFull')" />
+    <i18n path="about.quality.gaw-blurb.template" tag="p">
+      <template v-slot:gaw-qa>
+        <a :href="gawURL" target="_blank" v-text="$t('about.quality.gaw-blurb.gaw-qa')" />
+      </template>
+    </i18n>
+    <h2 v-text="$t('about.quality.sag.title')" />
+    <i18n path="about.quality.sag.blurb.template" tag="p">
+      <template v-slot:sop>
+        <nuxt-link :to="localePath('resources-sop')" v-text="$t('about.quality.sag.blurb.sop')" />
+      </template>
+    </i18n>
     <ul>
       <li v-for="link in sagLinks" :key="link.to">
-        <a :href="link.to">
-          {{ link.text }}
-        </a>
-        ({{ link.note }})
+        <a :href="link.to" v-text="link.text" /> ({{ link.note }})
       </li>
     </ul>
-    <h2>{{ $t('about.quality.eccc.title') }}</h2>
-    <p>{{ $t('about.quality.eccc.blurb') }}</p>
+    <h2 v-text="$t('about.quality.eccc.title')" />
+    <p v-text="$t('about.quality.eccc.blurb')" />
     <ul>
-      <li v-for="(blurb, i) in ecccItems" :key="i">
-        <woudc-blurb :items="blurb" />
+      <li>
+        <i18n path="about.quality.eccc.item1.template" tag="span">
+          <template v-slot:guidelines>
+            <nuxt-link :to="localePath('about-formats')" v-text="$t('about.quality.eccc.item1.guidelines')" />
+          </template>
+        </i18n>
+      </li>
+      <li v-text="$t('about.quality.eccc.item2')" />
+      <li v-text="$t('about.quality.eccc.item3')" />
+      <li v-text="$t('about.quality.eccc.item4')" />
+      <li v-text="$t('about.quality.eccc.item5')" />
+      <li>
+        <i18n path="about.quality.eccc.item6.template" tag="span">
+          <template v-slot:access>
+            <nuxt-link :to="localePath('about-dataaccess')" v-text="$t('about.quality.eccc.item6.access')" />
+          </template>
+        </i18n>
       </li>
     </ul>
   </v-layout>
 </template>
 
 <script>
-import WoudcBlurb from '~/components/WoudcBlurb'
-
-const sagURLs = [
-  'https://www.esrl.noaa.gov/gmd/ozwv/dobson/troubleshooting.html',
-  'http://exp-studies.tor.ec.gc.ca/e/ozone/ozone.htm',
-  'https://www.fz-juelich.de/iek/iek-8/EN/Expertise/Infrastructure/WCCOS/WCCOS_node.html'
-]
-
 export default {
-  components: {
-    'woudc-blurb': WoudcBlurb
-  },
   data() {
     return {
-      gawBlurb: [
-        { text: this.$t('about.quality.gaw-blurb[0]') },
-        { link: { to: 'https://www.wmo.int/pages/prog/arep/gaw/qassurance.html', type: 'external', text: this.$t('about.quality.gaw-blurb[1]') } },
-        { text: this.$t('about.quality.gaw-blurb[2]') }
-      ],
-      sagBlurb: [
-        { text: this.$t('about.quality.sag.blurb[0]') },
-        { link: { to: 'resources-sop', text: this.$t('about.quality.sag.blurb[1]') } },
-        { text: this.$t('about.quality.sag.blurb[2]') },
-        { newlines: 2 },
-        { text: this.$t('about.quality.sag.blurb[3]') },
-      ],
-      sagLinks: [...sagURLs.keys()].map((index) => {
-        const definition = this.$t('about.quality.sag.links[' + index + ']')
-        definition.to = sagURLs[index]
-        return definition
-      }),
-      ecccItems: [
-        [
-          { text: this.$t('about.quality.eccc.item1[0]') },
-          { link: { to: 'about-formats', text: this.$t('about.quality.eccc.item1[1]') } },
-          { text: this.$t('about.quality.eccc.item1[2]') }
-        ],
-        { text: this.$t('about.quality.eccc.item2[0]') },
-        { text: this.$t('about.quality.eccc.item3[0]') },
-        { text: this.$t('about.quality.eccc.item4[0]') },
-        { text: this.$t('about.quality.eccc.item5[0]') },
-        [
-          { text: this.$t('about.quality.eccc.item6[0]') },
-          { link: { to: 'about-dataaccess', text: this.$t('about.quality.eccc.item6[1]') } },
-          { text: this.$t('about.quality.eccc.item6[2]') },
-        ]
+      gawURL: 'https://www.wmo.int/pages/prog/arep/gaw/qassurance.html',
+      sagURLs: [
+        'https://www.esrl.noaa.gov/gmd/ozwv/dobson/troubleshooting.html',
+        'http://exp-studies.tor.ec.gc.ca/e/ozone/ozone.htm',
+        'https://www.fz-juelich.de/iek/iek-8/EN/Expertise/Infrastructure/WCCOS/WCCOS_node.html'
       ]
+    }
+  },
+  computed: {
+    sagLinks() {
+      const definitions = this.$t('about.quality.sag.links')
+
+      return [...definitions.keys()].map((index) => {
+        const defn = definitions[index]
+        defn.to = this.sagURLs[index]
+        return defn
+      })
     }
   },
   nuxtI18n: {
     paths: {
-      en: '/data-quality',
-      fr: '/qualite-donnees'
+      en: '/about/data-quality',
+      fr: '/apropos/qualite-donnees'
     }
   }
 }

--- a/pages/about/standards.vue
+++ b/pages/about/standards.vue
@@ -1,138 +1,128 @@
 <template>
   <v-layout justify-center column align-content-center>
-    <h1>{{ $t('about.standards.title') }}</h1>
-    <woudc-blurb :items="blurb1" />
+    <h1 v-text="$t('about.standards.title')" />
+    <i18n path="about.standards.blurb1.template" tag="p">
+      <template v-slot:interoperability>
+        <a :href="interoperabilityURL" target="_blank" v-text="$t('about.standards.blurb1.interoperability')" />
+      </template>
+      <template v-slot:wis>
+        <a :href="wisURL" target="_blank" v-text="$t('about.standards.blurb1.wis')" />
+      </template>
+    </i18n>
     <v-data-table
+      id="standards-table"
       :headers="headers"
       :items="rows"
       hide-default-footer
       class="elevation-1"
     >
       <template v-slot:item.formats="props">
-        <td>
-          <ul>
-            <li v-for="link in props.item.formats" :key="link.to">
-              <a :href="link.to">
-                {{ link.text }}
-              </a>
-            </li>
-          </ul>
-        </td>
+        <v-chip v-for="link in props.item.formats" :key="link.to" class="resource" label>
+          <a :href="link.to" v-text="link.text" />
+        </v-chip>
       </template>
       <template v-slot:item.services="props">
-        <td>
-          <ul>
-            <li v-for="link in props.item.services" :key="link.to">
-              <a :href="link.to">
-                {{ link.text }}
-              </a>
-            </li>
-          </ul>
-        </td>
+        <v-chip v-for="link in props.item.services" :key="link.to" class="resource" label>
+          <a :href="link.to" v-text="link.text" />
+        </v-chip>
       </template>
     </v-data-table>
-    <woudc-blurb :items="blurb2" />
+    <i18n path="about.standards.blurb2.template" tag="p">
+      <template v-slot:access>
+        <nuxt-link :to="localePath('about-dataaccess')" v-text="$t('about.standards.blurb2.access')" />
+      </template>
+    </i18n>
   </v-layout>
 </template>
 
 <script>
-import WoudcBlurb from '~/components/WoudcBlurb'
-
-const headerKeys = [ 'resource', 'formats', 'services' ]
-
-const linksURLs = [
-  {
-    formats: [
-      'https://www.wmo.int/pages/prog/www/metadata/WMO-core-metadata.html'
-    ],
-    services: [
-      'https://www.opengeospatial.org/standards/cat',
-      'https://www.openarchives.org/pmh/',
-      'http://www.opensearch.org/'
-    ]
-  },
-  {
-    formats: [
-      'https://www.opengeospatial.org/standards/gml',
-      'https://www.wmo.int/pages/prog/www/wigos/documents/Cg-17/WIGOS_Metadata.pdf'
-    ],
-    services: [
-      'https://www.opengeospatial.org/standards/wms',
-      'https://www.opengeospatial.org/standards/wfs'
-    ]
-  },
-  {
-    formats: [
-      'https://www.opengeospatial.org/standards/gml',
-      'https://www.wmo.int/pages/prog/www/wigos/documents/Cg-17/WIGOS_Metadata.pdf'
-    ],
-    services: [
-      'https://www.opengeospatial.org/standards/wms',
-      'https://www.opengeospatial.org/standards/wfs'
-    ]
-  },
-  {
-    formats: [
-      'https://en.wikipedia.org/wiki/Comma-separated_values',
-      'https://geojson.org/',
-      'https://www.opengeospatial.org/standards/gml',
-      'https://www.wmo.int/pages/prog/www/wigos/documents/Cg-17/WIGOS_Metadata.pdf'
-    ],
-    services: [
-      'https://www.opengeospatial.org/standards/wms',
-      'https://www.opengeospatial.org/standards/wfs'
-    ]
-  }
-]
-
 export default {
-  components: {
-    'woudc-blurb': WoudcBlurb
-  },
   data() {
     return {
-      blurb1: [
-        { text: this.$t('about.standards.blurb1[0]') },
-        { link: { to: 'https://www.wmo.int/pages/prog/www/WIS/documents/MOAWMO_OGC.pdf', type: 'external', text: this.$t('about.standards.blurb1[1]') } },
-        { text: this.$t('about.standards.blurb1[2]') },
-        { link: { to: 'https://www.wmo.int/pages/prog/www/WIS/', type: 'external', text: this.$t('about.standards.blurb1[3]') } },
-        { text: this.$t('about.standards.blurb1[4]') }
-      ],
-      blurb2: [
-        { text: this.$t('about.standards.blurb2[0]') },
-        { link: { to: 'about-dataaccess', text: this.$t('about.standards.blurb2[1]') } },
-        { text: '.' }
-      ],
-      headers: [...headerKeys.keys()].map((index) => {
+      interoperabilityURL: 'https://www.wmo.int/pages/prog/www/WIS/documents/MOAWMO_OGC.pdf',
+      wisURL: 'https://www.wmo.int/pages/prog/www/WIS/',
+      formatURLs: {
+        csv: 'https://en.wikipedia.org/wiki/Comma-separated_values',
+        geojson: 'https://geojson.org/',
+        gml: 'https://www.opengeospatial.org/standards/gml',
+        iso: 'https://www.wmo.int/pages/prog/www/metadata/WMO-core-metadata.html',
+        wigos: 'https://www.wmo.int/pages/prog/www/wigos/documents/Cg-17/WIGOS_Metadata.pdf'
+      },
+      serviceURLs: {
+        csw: 'https://www.opengeospatial.org/standards/cat',
+        pmh: 'https://www.openarchives.org/pmh/',
+        wfs: 'https://www.opengeospatial.org/standards/wfs',
+        wms: 'https://www.opengeospatial.org/standards/wms'
+      },
+      tableRowIdentifiers: [
+        {
+          formats: [ 'iso' ],
+          services: [ 'csw', 'pmh', 'opensearch' ]
+        },
+        {
+          formats: [ 'gml', 'wigos' ],
+          services: [ 'wms', 'wfs' ]
+        },
+        {
+          formats: [ 'gml', 'wigos' ],
+          services: [ 'wms', 'wfs' ]
+        },
+        {
+          formats: [ 'csv', 'geojson', 'gml', 'wigos' ],
+          services: [ 'wms', 'wfs' ]
+        }
+      ]
+    }
+  },
+  computed: {
+    headers() {
+      const headerKeys = [ 'resource', 'formats', 'services' ]
+      return [...headerKeys.keys()].map((index) => {
         return {
           text: this.$t('about.standards.headers[' + index + ']'),
           value: headerKeys[index]
         }
-      }),
-      rows: [...linksURLs.keys()].map((index) => {
+      })
+    },
+    rows() {
+      return [...this.tableRowIdentifiers.keys()].map((index) => {
+        const formatsList = this.tableRowIdentifiers[index].formats.map((format) => {
+          return {
+            text: this.$t('about.standards.links.formats.' + format),
+            to: this.formatURLs[format]
+          }
+        })
+        const servicesList = this.tableRowIdentifiers[index].services.map((service) => {
+          return {
+            text: this.$t('about.standards.links.services.' + service),
+            to: this.serviceURLs[service]
+          }
+        })
+
         return {
-          resource: this.$t('about.standards.links[' + index + '].resource'),
-          formats: [...linksURLs[index].formats.keys()].map((index2) => {
-            return {
-              text: this.$t('about.standards.links[' + index + '].formats[' + index2 + ']'),
-              to: linksURLs[index].formats[index2]
-            }
-          }),
-          services: [...linksURLs[index].services.keys()].map((index3) => {
-            return {
-              text: this.$t('about.standards.links[' + index + '].services[' + index3 + ']'),
-              to: linksURLs[index].services[index3]
-            }
-          }),
+          resource: this.$t('about.standards.links.resources[' + index + ']'),
+          formats: formatsList,
+          services: servicesList
         }
       })
     }
   },
   nuxtI18n: {
     paths: {
-      en: '/standards',
-      fr: '/normes'
+      en: '/about/standards',
+      fr: '/apropos/normes'
     }
   }
 }
 </script>
+
+<style scoped>
+#standards-table .v-chip {
+  margin-right: 8px;
+  background-color: #e8e8e8;
+}
+
+#standards-table .v-chip a {
+  text-decoration: none;
+}
+</style>


### PR DESCRIPTION
First of two pull requests that removes all occurrences of the `woudc-blurb`, `woudc-note`, and `woudc-link` components and replaces them with straight-up Vue components.

Affects half the pages in the About section, focusing on the larger and/or more complex pages: data access, policy, quality, and standards pages.

Intended as part of a cleanup of the translation system, so that blurbs are built using readable component substitution rather than being set up behind-the-scenes by all these components. So translations in the JSON files and their uses in the Vue components have been cleaned up in the four About section pages.