### PR TITLE
Unpack Components - About Section 2

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -262,6 +262,10 @@
     },
     "glossary": {
       "blurb": "Terms related to the data centre, including definitions about network operations centres and words and phrases about the storage, management and the transmission of data.",
+      "substitutions": {
+        "carcinogenesis": "carcinogenesis effectiveness",
+        "registration": "contributor registration form"
+      },
       "terms": [
         {
           "term": "Agency",
@@ -325,11 +329,7 @@
         },
         {
           "term": "Erythemal",
-          "definition": [
-            "The solar erythemal ultraviolet (UV) radiation which is defined by the integral over the UV wavelengths of the irradiance multiplied by the erythemal action spectrum (refer to ",
-            { "link": { "to": "https://www.wmo.int/pages/prog/dra/etrp/documents/926E.pdf", "type": "external", "text": "carcinogenesis effectiveness" } },
-            ")."
-          ]
+          "definition": "The solar erythemal ultraviolet (UV) radiation which is defined by the integral over the UV wavelengths of the irradiance multiplied by the erythemal action spectrum (refer to {carcinogenesis})."
         },
         {
           "term": "extCSV",
@@ -341,11 +341,7 @@
         },
         {
           "term": "File Format Version",
-          "definition": [
-            "The WOUDC term for the format of a data file. Data files of a given content will always contain the tables and fields specified by the WOUDC for that form. Refer to ",
-            { "link": { "to": "contributors-registration", "text": "contributor registration form" } },
-            "."
-          ]
+          "definition": "The WOUDC term for the format of a data file. Data files of a given content will always contain the tables and fields specified by the WOUDC for that form. Refer to {registration}."
         },
         {
           "term": "Form",
@@ -461,11 +457,7 @@
         },
         {
           "term": "RDF",
-          "definition": [
-            "Resource Description Framework - A part of the SKOS Web Service standard from World Wide Web Consortium (",
-            { "link": { "to": "https://www.w3.org/", "type": "external", "text": "www.w3.org" } },
-            ")."
-          ]
+          "definition": "Resource Description Framework - A part of the SKOS Web Service standard from World Wide Web Consortium ({w3})."
         },
         {
           "term": "Revision",
@@ -497,11 +489,7 @@
         },
         {
           "term": "SKOS",
-          "definition": [
-            "Simple Knowledge Organization System - A part of the Web Service standard from World Wide Web Consortium (",
-            { "link": { "to": "https://www.w3.org/", "type": "external", "text": "www.w3.org" } },
-            ")."
-          ]
+          "definition": "Simple Knowledge Organization System - A part of the Web Service standard from World Wide Web Consortium ({w3})."
         },
         {
           "term": "S/N",
@@ -561,11 +549,7 @@
         },
         {
           "term": "Web Accessible Folder (WAF)",
-          "definition": [
-            "The entire archive of contributed data files in Extended CSV format is made available at ",
-            { "link": { "to": "https://woudc.org/archive", "type": "external", "text": "https://woudc.org/archive/" } },
-            " for users to browse, download or integrate into their workflows."
-          ]
+          "definition": "The entire archive of contributed data files in Extended CSV format is made available at {waf} for users to browse, download or integrate into their workflows."
         },
         {
           "term": "Web Feature Service (WFS)",

--- a/locales/en.json
+++ b/locales/en.json
@@ -225,25 +225,19 @@
       "title": "Frequently Asked Questions"
     },
     "formats": {
-      "blurb": [
-        "The WOUDC uses ASCII text file format standard for data submissions in an ",
-        " (ext) Comma-Separated Value (CSV) format.",
-        "The extended CSV (extCSV) is the standard data file format for submission to WOUDC. The ",
-        " standard for the CSV syntax rules support the provision of comments and multiple data content within individual files. The extCSV provides a simple text-based format for data providers when submitting data to the WOUDC, as well as one of many ways for users to integrate ozone and ultraviolet (UV) radiation data into their database, spreadsheet and workflow analysis. Please refer to the ",
-        "data access",
-        " page for more information on WOUDC data discovery, access and visualization."
-      ],
+      "blurb": {
+        "access": "data access",
+        "extended": "extended",
+        "template": "The WOUDC uses ASCII text file format standard for data submissions in an {extcsv} (ext) Comma-Separated Value (CSV) format.\n\nThe extended CSV (extCSV) is the standard data file format for submission to WOUDC. The {extended} standard for the CSV syntax rules support the provision of comments and multiple data content within individual files. The extCSV provides a simple text-based format for data providers when submitting data to the WOUDC, as well as one of many ways for users to integrate ozone and ultraviolet (UV) radiation data into their database, spreadsheet and workflow analysis. Please refer to the {access} page for more information on WOUDC data discovery, access and visualization."
+      },
       "contributor-guide": {
-        "links": [
-          "WOUDC Contributor Guide"
-        ],
+        "link": "WOUDC Contributor Guide",
         "title": "Contributor Guide"
       },
       "examples": {
         "blurb": "The following examples of extCSV files are based on the observation category (open files in a text editor):",
         "title": "Examples: extended Comma-Separated Value"
       },
-      "extended": "extended",
       "note": " The WOUDC does not accept files in binary formats such as MS-Excel or MS-Word.",
       "ozone": {
         "links": [

--- a/locales/en.json
+++ b/locales/en.json
@@ -621,31 +621,23 @@
       "title": "Glossary"
     },
     "home": {
-      "blurb": [
-        "The World Ozone and Ultraviolet Radiation Data Centre (WOUDC) is one of six World Data Centres which are part of the Global Atmosphere Watch programme of the World Meteorological Organization. The WOUDC data centre is operated by the Meteorological Service of Canada, a branch of Environment and Climate Change Canada.",
-        "Ozone data set categories include total column ozone and vertical profile data from lidar measurements, ozonesonde flights, and the Umkehr technique. Ultraviolet (UV) radiation data set categories include broadband, multiband, and high resolution spectral data types.",
-        "There are over 500 registered ",
-        "stations",
-        " in the archive from over 150 ",
-        "contributors",
-        ". Metadata such as station lists with locations, are available from the WOUDC Website.",
-        "Value added data products include total ozone time series graphs and near real-time ozone maps.",
-        "All WOUDC data are made available by using the ",
-        "data search / download",
-        ", or web accessible folder (WAF) access. In addition, the Open Geospatial Consortium web services provide enhanced access to the archive, which provides standards-based-on-demand access to the archive. For more information, please refer to the ",
-        "data access",
-        " page."
-      ],
+      "blurb": {
+        "access": "data access",
+        "contributors": "contributors",
+        "search": "data search / download",
+        "stations": "stations",
+        "template": "The World Ozone and Ultraviolet Radiation Data Centre (WOUDC) is one of six World Data Centres which are part of the Global Atmosphere Watch programme of the World Meteorological Organization. The WOUDC data centre is operated by the Meteorological Service of Canada, a branch of Environment and Climate Change Canada.\n\nOzone data set categories include total column ozone and vertical profile data from lidar measurements, ozonesonde flights, and the Umkehr technique. Ultraviolet (UV) radiation data set categories include broadband, multiband, and high resolution spectral data types.\n\nThere are over 500 registered {stations} in the archive from over 150 {contributors}. Metadata such as station lists with locations, are available from the WOUDC Website.\n\nValue added data products include total ozone time series graphs and near real-time ozone maps.\n\nAll WOUDC data are made available by using the {search}, or web accessible folder (WAF) access. In addition, the Open Geospatial Consortium web services provide enhanced access to the archive, which provides standards-based-on-demand access to the archive. For more information, please refer to the {access} page."
+      },
       "history": {
-        "milestones": [
-          "World Ozone Data Centre (WODC) created",
-          "first publication of Ozone Data for the World issued",
-          "solar ultraviolet (UV) radiation data is added to the data archives; data centre renamed to World Ozone and Ultraviolet Radiation Data Centre (WOUDC)",
-          "initial website and FTP site created",
-          "first data CD ROM produced",
-          "first data DVD ROM with complete data archive released",
-          "website updated, providing modernized mechanisms supporting discovery, visualization, access and management of ozone and UV data"
-        ],
+        "milestones": {
+          "1960": "World Ozone Data Centre (WODC) created",
+          "1964": "first publication of Ozone Data for the World issued",
+          "1992": "solar ultraviolet (UV) radiation data is added to the data archives; data centre renamed to World Ozone and Ultraviolet Radiation Data Centre (WOUDC)",
+          "1995": "initial website and FTP site created",
+          "1996": "first data CD ROM produced",
+          "2006": "first data DVD ROM with complete data archive released",
+          "2015": "website updated, providing modernized mechanisms supporting discovery, visualization, access and management of ozone and UV data"
+        },
         "title": "History of the Data Centre"
       },
       "title": "About WOUDC"

--- a/locales/en.json
+++ b/locales/en.json
@@ -154,74 +154,54 @@
       "blurb": "Here are the answers to some of the most frequently asked questions about our data centre.",
       "questions": [
         {
-          "text": "Who can access the WOUDC data?",
-          "answer": [
-            "The WOUDC is a public website in support of the WMO Global Atmospheric Watch (GAW) programme. WOUDC data is made publically available on behalf of data contributors. For information on data access and usage, please refer to the ",
-            "data policy page"
-          ]
+          "answer": "The WOUDC is a public website in support of the WMO Global Atmospheric Watch (GAW) programme. WOUDC data is made publically available on behalf of data contributors. For information on data access and usage, please refer to the {policy}.",
+          "text": "Who can access the WOUDC data?"
         },
         {
-          "text": "How do I submit data?",
-          "answer": [
-            "Registered contributors can submit data to the WOUDC via FTP. Visit the ",
-            "data submission",
-            " page for all of the details. All new data contributors require a WOUDC account. To become a contributor, please visit the ",
-            "registration page"
-          ]
+          "answer": "Registered contributors can submit data to the WOUDC via FTP. Visit the {submission} page for all of the details. All new data contributors require a WOUDC account. To become a contributor, please visit the {registration}.",
+          "text": "How do I submit data?"
         },
         {
-          "text": "How do I access the WOUDC data archive?",
-          "answer": [
-            "Registered contributors can access the WOUDC data archive using the WOUDC website, geospatial tools or custom solutions. Visit the ",
-            "data access",
-            " page for all the details."
-          ]
+          "answer": "Registered contributors can access the WOUDC data archive using the WOUDC website, geospatial tools or custom solutions. Visit the {access} page for all the details.",
+          "text": "How do I access the WOUDC data archive?"
         },
         {
-          "text": "What data can I find in WOUDC?",
-          "answer": [
-            "The WOUDC currently manages and provides Ozone and Ultra Violet Radiation data. Please refer to ",
-            "data search / download",
-            " to see all WOUDC datasets. Other products such as maps, graphs and reports are also available on the ",
-            "data products",
-            " page."
-          ]
+          "answer": "The WOUDC currently manages and provides Ozone and Ultra Violet Radiation data. Please refer to {search} to see all WOUDC datasets. Other products such as maps, graphs and reports are also available on the {products} page.",
+          "text": "What data can I find in WOUDC?"
         },
         {
-          "text": "Where does WOUDC get its data from?",
-          "answer": [
-            "WOUDC data comes from worldwide contributors consisting of institutions, agencies and organizations. Contributors submit their data to WOUDC, where the data are then archived and made available. Please refer to ",
-            "contributor list"
-          ]
+          "answer": "WOUDC data comes from worldwide contributors consisting of institutions, agencies and organizations. Contributors submit their data to WOUDC, where the data are then archived and made available. Please refer to {contributors}.",
+          "text": "Where does WOUDC get its data from?"
         },
         {
-          "text": "How frequently is data updated?",
-          "answer": "Data is typically updated and made available to users within five business day of receipt by WOUDC. Extended CSV (extCSV) data are processed and made available in near real time."
+          "answer": "Data is typically updated and made available to users within five business day of receipt by WOUDC. Extended CSV (extCSV) data are processed and made available in near real time.",
+          "text": "How frequently is data updated?"
         },
         {
-          "text": "Who is responsible for keeping WOUDC information up-to-date?",
-          "answer": "WOUDC uses information provided by contributors who submit data. The WOUDC is responsible for ensuring that the most recent information provided by the contributors is available to all users."
+          "answer": "WOUDC uses information provided by contributors who submit data. The WOUDC is responsible for ensuring that the most recent information provided by the contributors is available to all users.","text": "Who is responsible for keeping WOUDC information up-to-date?",
+          "text": "Who is responsible for keeping WOUDC information up-to-date?"
         },
         {
-          "text": "Can I use my application to automatically retrieve data from WOUDC and also to upload data to WOUDC?",
-          "answer": [
-            "Yes. The WOUDC provides raw data through a web accessible folder (WAF) as well as Open Geospatial Consortium web services such as Web Map Service and Web Feature Service, providing dynamic, real-time access of the WOUDC data in numerous formats and encodings. For more information, please refer to the ",
-            "data access",
-            " page."
-          ]
+          "answer": "Yes. The WOUDC provides raw data through a web accessible folder (WAF) as well as Open Geospatial Consortium web services such as Web Map Service and Web Feature Service, providing dynamic, real-time access of the WOUDC data in numerous formats and encodings. For more information, please refer to the {access} page.",
+          "text": "Can I use my application to automatically retrieve data from WOUDC and also to upload data to WOUDC?"
         },
         {
-          "text": "Can I use my handheld device to access WOUDC?",
-          "answer": [
-            "Yes. The WOUDC web application has been developed using Government of Canada directives on ",
-            "accessibility",
-            " and ",
-            "usability",
-            ", which align with ",
-            "W3C Web Content Accessibility Guidelines"
-          ]
+          "answer": "Yes. The WOUDC web application has been developed using Government of Canada directives on {accessibility} and {usability}, which align with {w3c}",
+          "text": "Can I use my handheld device to access WOUDC?"
         }
       ],
+      "substitutions": {
+        "access": "data access",
+        "accessibility": "accessibility",
+        "contributors": "contributor list",
+        "policy": "data policy page",
+        "products": "data products",
+        "registration": "registration page",
+        "search": "data search / download",
+        "submission": "data submission",
+        "usability": "usability",
+        "w3c": "W3C Web Content Accessibility Guidelines"
+      },
       "title": "Frequently Asked Questions"
     },
     "formats": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -625,31 +625,23 @@
       "title": "Glossaire"
     },
     "home": {
-      "blurb": [
-        "Le Centre mondial de données sur l’ozone et le rayonnement ultraviolet (WOUDC) est l’undes six Centres mondiaux de données reconnus qui font partie du programme de Veille de l’atmosphère du globe de l’Organisation météorologique mondiale. Le centre de données du WOUDC est exploité par Service météorologique du Canada, une branche d’Environnement et Changement climatique Canada.",
-        "Les catégories d’ensembles de données sur l’ozone comprennent les mesures de la colonne d’ozone total et de la courbe de répartition verticale de l’ozone relevées par des lidar, des sondes pour l’ozone en vol et par la technique Umkehr. Les catégories d’ensemble de données sur le rayonnement ultraviolet (UV) incluent les données de type spectrale, à large bande, multibande et à haute résolution.",
-        "Il y a plus de 500 ",
-        "stations enregistrées",
-        " dans les archives, provenant de plus de 150 ",
-        "contributeurs",
-        ". Des métadonnées telles que les listes des stations et leur emplacement sont offertes sur le site Web du WOUDC.",
-        "Les données à valeur ajoutée incluent les graphiques représentant la quantité totale d’ozone, classés en ordre chronologique, et les cartes des quantités d’ozone qui en montrent l’évolution en temps quasi réel.",
-        "Toutes les données du WOUDC sont fournies en utilisant la ",
-        "recherche de données / téléchargement",
-        ", ou pardossier accessible sur le web (WAF). De plus, les services web de l’Open Geospatial Consortium fournissent une accessibilité accrue aux archives ce qui permet un accès sur demande conforme aux normes. Pour obtenir de plus amples renseignements, veuillez vous référer à la ",
-        "d'accès aux données",
-        "."
-      ],
+      "blurb": {
+        "access": "d'accès aux données",
+        "contributors": "contributeurs",
+        "search": "recherche de données / téléchargement",
+        "stations": "stations enregistrées",
+        "template": "Le Centre mondial de données sur l’ozone et le rayonnement ultraviolet (WOUDC) est l’undes six Centres mondiaux de données reconnus qui font partie du programme de Veille de l’atmosphère du globe de l’Organisation météorologique mondiale. Le centre de données du WOUDC est exploité par Service météorologique du Canada, une branche d’Environnement et Changement climatique Canada.\n\nLes catégories d’ensembles de données sur l’ozone comprennent les mesures de la colonne d’ozone total et de la courbe de répartition verticale de l’ozone relevées par des lidar, des sondes pour l’ozone en vol et par la technique Umkehr. Les catégories d’ensemble de données sur le rayonnement ultraviolet (UV) incluent les données de type spectrale, à large bande, multibande et à haute résolution.\n\nIl y a plus de 500 {stations} dans les archives, provenant de plus de 150 {contributors}. Des métadonnées telles que les listes des stations et leur emplacement sont offertes sur le site Web du WOUDC.\n\nLes données à valeur ajoutée incluent les graphiques représentant la quantité totale d’ozone, classés en ordre chronologique, et les cartes des quantités d’ozone qui en montrent l’évolution en temps quasi réel.\n\nToutes les données du WOUDC sont fournies en utilisant la {search}, ou pardossier accessible sur le web (WAF). De plus, les services web de l’Open Geospatial Consortium fournissent une accessibilité accrue aux archives ce qui permet un accès sur demande conforme aux normes. Pour obtenir de plus amples renseignements, veuillez vous référer à la {access}."
+      },
       "history": {
-        "milestones": [
-          "Le Centre mondial des données sur l’ozone (WODC) a vu le jour",
-          "la première publication de données sur l’ozone à l’échelle mondiale du WODC a été émise",
-          "les données sur le rayonnement solaire ultraviolet (UV) ont été ajoutées aux archives ; le centre de données a alors été rebaptisé le Centre mondial de données sur l’ozone et le rayonnement ultraviolet (WOUDC)",
-          "site initial et le site FTP ont été créé",
-          "les premières données du cdrom ont été produites",
-          "les premières données du DVD ROM avec l'archive complète sont sorties",
-          "le site Web du WOUDC, mis à jour, fournit des mécanismes modernisés qui soutiennent la découverte, la visualisation et la gestion des données sur l’ozone et les UV, en plus d’en favoriser l’accessibilité"
-        ],
+        "milestones": {
+          "1960": "Le Centre mondial des données sur l’ozone (WODC) a vu le jour",
+          "1964": "la première publication de données sur l’ozone à l’échelle mondiale du WODC a été émise",
+          "1992": "les données sur le rayonnement solaire ultraviolet (UV) ont été ajoutées aux archives ; le centre de données a alors été rebaptisé le Centre mondial de données sur l’ozone et le rayonnement ultraviolet (WOUDC)",
+          "1995": "site initial et le site FTP ont été créé",
+          "1996": "les premières données du cdrom ont été produites",
+          "2006": "les premières données du DVD ROM avec l'archive complète sont sorties",
+          "2015": "le site Web du WOUDC, mis à jour, fournit des mécanismes modernisés qui soutiennent la découverte, la visualisation et la gestion des données sur l’ozone et les UV, en plus d’en favoriser l’accessibilité"
+        },
         "title": "Le centre de données - un peu d’histoire"
       },
       "title": "Qu’est-ce que le WOUDC"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -262,6 +262,9 @@
     },
     "glossary": {
       "blurb": "Termes reliés au centre des données, y compris les définitions portant sur les centres d’exploitation du réseau et les mots et phrases qui portent sur l’entreposage, la gestion et la transmission de données.",
+      "substitutions": {
+        "registration": "formulaire d’inscription des contributeurs"
+      },
       "terms": [
         {
           "term": "Acronyme de l’organisme",
@@ -317,11 +320,7 @@
         },
         {
           "term": "Dossier accessible sur le web (WAF)",
-          "definition": [
-            "Toutes les archives de fichiers de données qui ont été envoyées par les contributeurs en format CSV étendu sont disponibles au ",
-            { "link": { "to": "https://woudc.org/archive", "type": "external", "text": "https://woudc.org/archive/" } },
-            " pour les utilisateurs qui souhaitent consulter ou télécharger les données ou les intégrer dans leurs chaînes d’exploitation."
-          ]
+          "definition": "Toutes les archives de fichiers de données qui ont été envoyées par les contributeurs en format CSV étendu sont disponibles au {waf} pour les utilisateurs qui souhaitent consulter ou télécharger les données ou les intégrer dans leurs chaînes d’exploitation."
         },
         {
           "term": "DSS",
@@ -333,11 +332,7 @@
         },
         {
           "term": "Érythémateux",
-          "definition": [
-            "Le rayonnement solaire ultraviolet à effet érythémateux se définit comme l’intégrale sur les longueurs d’onde UV de l’irradiation, multipliée par le spectre à action érythémateuse (consulter ",
-            { "link": { "to": "https://www.wmo.int/pages/prog/dra/etrp/documents/926E.pdf", "type": "external", "text": "efficacité sur la carcinogenèse" } },
-            ")."
-          ]
+          "definition": "Le rayonnement solaire ultraviolet à effet érythémateux se définit comme l’intégrale sur les longueurs d’onde UV de l’irradiation, multipliée par le spectre à action érythémateuse (consulter {carcinogenesis})."
         },
         {
           "term": "extCSV",
@@ -477,11 +472,7 @@
         },
         {
           "term": "RDF",
-          "definition": [
-            "Resource Description Framework - Une partie de la norme de service Web SKOS de World Wide Web Consortium (",
-            { "link": { "to": "https://www.w3.org/", "type": "external", "text": "www.w3.org" } },
-            ")."
-          ]
+          "definition": "Resource Description Framework - Une partie de la norme de service Web SKOS de World Wide Web Consortium ({w3})."
         },
         {
           "term": "Régions de l’OMM",
@@ -525,11 +516,7 @@
         },
         {
           "term": "SKOS",
-          "definition": [
-            "Simple Knowledge Organization System - Une partie de la norme du Consortium World Wide Web Service Web (",
-            { "link": { "to": "https://www.w3.org/", "type": "external", "text": "www.w3.org" } },
-            ")."
-          ]
+          "definition": "Simple Knowledge Organization System - Une partie de la norme du Consortium World Wide Web Service Web ({w3})."
         },
         {
           "term": "S/N",
@@ -601,19 +588,11 @@
         },
         {
           "term": "Version du format de fichier",
-          "definition": [
-            "Terme propre au WOUDC pour décrire le format d’un fichier de données. Les fichiers de données portant sur un sujet précis contiendront toujours les tableaux et les champs définis par le WOUDC pour ce formulaire. Consulter le ",
-            { "link": { "to": "contributors-registration", "text": "formulaire d’inscription des contributeurs" } },
-            "."
-          ]
+          "definition": "Terme propre au WOUDC pour décrire le format d’un fichier de données. Les fichiers de données portant sur un sujet précis contiendront toujours les tableaux et les champs définis par le WOUDC pour ce formulaire. Consulter le {registration}."
         },
         {
           "term": "WOUDC",
           "definition": "Le Centre mondial de données sur l’ozone et le rayonnement ultraviolet."
-        },
-        {
-          "term": "",
-          "definition": ""
         }
       ],
       "title": "Glossaire"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -154,74 +154,54 @@
       "blurb": "Voici les réponses aux questions les plus fréquemment poséesà propos de notre centre de données.",
       "questions": [
         {
-          "text": "Qui peut consulter les données du WOUDC ?",
-          "answer": [
-            "Le WOUDC est un site Web public qui appuie le programme de Veille de l’atmosphère globale (VAG) de l’OMM. Les données du WOUDC sont rendues publiques au nom de leurs contributeurs. Pour plus d’information à propos des données, de leur accessibilité et leur utilisation, voir la ",
-            "politique sur les données"
-          ]
+          "answer": "Le WOUDC est un site Web public qui appuie le programme de Veille de l’atmosphère globale (VAG) de l’OMM. Les données du WOUDC sont rendues publiques au nom de leurs contributeurs. Pour plus d’information à propos des données, de leur accessibilité et leur utilisation, voir la {policy}.",
+          "text": "Qui peut consulter les données du WOUDC ?"
         },
         {
-          "text": "Comment puis-je soumettre des données ?",
-          "answer": [
-            "Les contributeurs inscrits peuvent soumettre des données au WOUDC par FTP. Rendez-vous à la page de ",
-            "soumission des données",
-            " pour tous les détails. Créer de nouvelles données requiert un compte d’utilisateur du WOUDC. Pour devenir contributeur, visitez la page ",
-            "d’inscription"
-          ]
+          "answer": "Les contributeurs inscrits peuvent soumettre des données au WOUDC par FTP. Rendez-vous à la page de {submission} pour tous les détails. Créer de nouvelles données requiert un compte d’utilisateur du WOUDC. Pour devenir contributeur, visitez la page {registration}.",
+          "text": "Comment puis-je soumettre des données ?"
         },
         {
-          "text": "Comment puis-je accéder aux données du WOUDC ?",
-          "answer": [
-            "Les contributeurs enregistrés peuvent accéder aux données du WOUDC par l’entremise du site web du WOUDC, d’outils de renseignement géospatial ou d’autres solutions. Visitez la page d’",
-            "accès aux données",
-            " pourtous les détails."
-          ]
+          "answer": "Les contributeurs enregistrés peuvent accéder aux données du WOUDC par l’entremise du site web du WOUDC, d’outils de renseignement géospatial ou d’autres solutions. Visitez la page d’{access} pourtous les détails.",
+          "text": "Comment puis-je accéder aux données du WOUDC ?"
         },
         {
-          "text": "Quel genre de données trouverais-je dans le WOUDC ?",
-          "answer": [
-            "Le WOUDC gère et conserve des données sur l’ozone etle rayonnement UV. Veuillez vous référer au ",
-            "recherche de données / téléchargement",
-            " pour consulter la listedes ensembles de données du WOUDC. D’autres produits, comme des cartes, des graphiques et des rapports, sont également disponibles sur la page de ",
-            "données",
-            "."
-          ]
+          "answer": "Le WOUDC gère et conserve des données sur l’ozone etle rayonnement UV. Veuillez vous référer au {search} pour consulter la listedes ensembles de données du WOUDC. D’autres produits, comme des cartes, des graphiques et des rapports, sont également disponibles sur la page de {products}.",
+          "text": "Quel genre de données trouverais-je dans le WOUDC ?"
         },
         {
-          "text": "D’où viennent les données du WOUDC ?",
-          "answer": [
-            "Les données du WOUDC sont recueillies et partagées par des contributeurs de partout dans le monde, soit des établissements, des agences et des organisations. Les contributeurs soumettent leurs données au WOUDC, qui conserve les données et les rend disponibles sur son site web. Voir la ",
-            "liste des contributeurs"
-          ]
+          "answer": "Les données du WOUDC sont recueillies et partagées par des contributeurs de partout dans le monde, soit des établissements, des agences et des organisations. Les contributeurs soumettent leurs données au WOUDC, qui conserve les données et les rend disponibles sur son site web. Voir la {contributors}.",
+          "text": "D’où viennent les données du WOUDC ?"
         },
         {
-          "text": "À quelle fréquence les données sont-elles mises à jour ?",
-          "answer": "Les données sont normalement mises à jour et disponibles pour la consultation cinq jours ouvrables après leur réception par le WOUDC. Les données en format CSV étendu (extCSV) sont traitées et mises en ligne presque immédiatement."
+          "answer": "Les données sont normalement mises à jour et disponibles pour la consultation cinq jours ouvrables après leur réception par le WOUDC. Les données en format CSV étendu (extCSV) sont traitées et mises en ligne presque immédiatement.",
+          "text": "À quelle fréquence les données sont-elles mises à jour ?"
         },
         {
-          "text": "Qui est responsable de la mise à jour des données du WOUDC ?",
-          "answer": "Le WOUDC utilise les informations que lui soumettent des contributeurs. Les WOUDC s’assure que les informations les plus récentes envoyées par le contributeur sont disponibles pour tous les utilisateurs."
+          "answer": "Le WOUDC utilise les informations que lui soumettent des contributeurs. Les WOUDC s’assure que les informations les plus récentes envoyées par le contributeur sont disponibles pour tous les utilisateurs.",
+          "text": "Qui est responsable de la mise à jour des données du WOUDC ?"
         },
         {
-          "text": "Est-ce que je peux me servir de mon application pour consulter des données du WOUDCet envoyer des données au WOUDC ?",
-          "answer": [
-            "Oui. Le WOUDC permet d’accéder aux données brutes par dossier accessible sur le web (WAF) ou les services Web de l’Open Geospatial Consortium tels que des services de cartographie web et des Service de caractéristiques web, procurant une accessibilité dynamique en temps réel aux données du WOUDC dans une variété de formats et d’encodages. Pour obtenir de plus amples renseignements, veuillez vous référer au d’",
-            "accès aux données",
-            "."
-          ]
+          "answer": "Oui. Le WOUDC permet d’accéder aux données brutes par dossier accessible sur le web (WAF) ou les services Web de l’Open Geospatial Consortium tels que des services de cartographie web et des Service de caractéristiques web, procurant une accessibilité dynamique en temps réel aux données du WOUDC dans une variété de formats et d’encodages. Pour obtenir de plus amples renseignements, veuillez vous référer au d’{access}.",
+          "text": "Est-ce que je peux me servir de mon application pour consulter des données du WOUDCet envoyer des données au WOUDC ?"
         },
         {
-          "text": "Puis-je utiliser mon appareil mobile pour accéder au WOUDC ?",
-          "answer": [
-            "Oui. L’application web du WOUDC a été mise sur pied à partir des directives du gouvernement du Canada à propos de ",
-            "l’accessibilité",
-            " et ",
-            "l’utilisation",
-            ", qui sont alignées avec ",
-            "les directives d’accessibilité du contenu du site web W3C"
-          ]
+          "answer": "Oui. L’application web du WOUDC a été mise sur pied à partir des directives du gouvernement du Canada à propos de {accessibility} et {usability}, qui sont alignées avec {w3c}.",
+          "text": "Puis-je utiliser mon appareil mobile pour accéder au WOUDC ?"
         }
       ],
+      "substitutions": {
+        "access": "accès aux données",
+        "accessibility": "l’accessibilité",
+        "contributors": "liste des contributeurs",
+        "policy": "politique sur les données",
+        "products": "données",
+        "registration": "d’inscription",
+        "search": "recherche de données / téléchargement",
+        "submission": "soumission des données",
+        "usability": "l’utilisation",
+        "w3c": "les directives d’accessibilité du contenu du site web W3C"
+      },
       "title": "Foire aux questions"
     },
     "formats": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -225,25 +225,19 @@
       "title": "Foire aux questions"
     },
     "formats": {
-      "blurb": [
-        "Le WOUDC utilise le format de fichier texte ASCII pour la soumission de données dans un format CSV ",
-        " (ext).",
-        "Le format CSV étendu (extCSV) est le format de fichier de données standard pour les soumissions au WOUDC. Le format ",
-        " standard pour les règles de syntaxe du CSV prend en charge la formulation des observations ainsi que de multiple contenus dans des fichiers individuels. Lorsque les fournisseurs désirent soumettre des données au WOUDC, le extCSV leur simplifie la tâche avec un format texte classiqueen plus de leur permettre d’intégrer des données sur l’ozone et le rayonnement ultraviolet (UV) dans leur base de données, leur feuille de calcul et leurs analyses du déroulement du travail. Veuillez consulter la ",
-        "d'accès aux données",
-        " pour plus de renseignements au sujet de la découverte, de l’accessibilité et de la visualisation des données du WOUDC."
-      ],
+      "blurb": {
+        "access": "d'accès aux données",
+        "extended": "étendu",
+        "template": "Le WOUDC utilise le format de fichier texte ASCII pour la soumission de données dans un format CSV {extended} (ext).\n\nLe format CSV étendu (extCSV) est le format de fichier de données standard pour les soumissions au WOUDC. Le format {extended} standard pour les règles de syntaxe du CSV prend en charge la formulation des observations ainsi que de multiple contenus dans des fichiers individuels. Lorsque les fournisseurs désirent soumettre des données au WOUDC, le extCSV leur simplifie la tâche avec un format texte classiqueen plus de leur permettre d’intégrer des données sur l’ozone et le rayonnement ultraviolet (UV) dans leur base de données, leur feuille de calcul et leurs analyses du déroulement du travail. Veuillez consulter la {access} pour plus de renseignements au sujet de la découverte, de l’accessibilité et de la visualisation des données du WOUDC."
+      },
       "contributor-guide": {
-        "links": [
-          "Guide du contributeur WOUDC"
-        ],
+        "link": "Guide du contributeur WOUDC",
         "title": "Guide du contributeur"
       },
       "examples": {
         "blurb": "Les exemples de fichiers extCSV suivants sont fondés sur la catégorie Observations (ouvrir les fichiers dans un éditeur de texte) :",
         "title": "Exemple: format CSV (extended CSV)"
       },
-      "extended": "étendu",
       "note": " Le WOUDC n’accepte pas les fichiers en format binaire comme les fichiers MS-Excel ou MS-Word, par exemple.",
       "ozone": {
         "links": [

--- a/pages/about/dataaccess.vue
+++ b/pages/about/dataaccess.vue
@@ -291,7 +291,7 @@ export default {
   nuxtI18n: {
     paths: {
       en: '/about/data-access',
-      fr: '/apropos/data-access-fr'
+      fr: '/a-propos/accessibilite-donnees'
     }
   }
 }

--- a/pages/about/datapolicy.vue
+++ b/pages/about/datapolicy.vue
@@ -92,7 +92,7 @@ export default {
   nuxtI18n: {
     paths: {
       en: '/about/data-policy',
-      fr: '/apropos/politique-donnees'
+      fr: '/a-propos/politique-donnees'
     }
   }
 }

--- a/pages/about/dataquality.vue
+++ b/pages/about/dataquality.vue
@@ -70,7 +70,7 @@ export default {
   nuxtI18n: {
     paths: {
       en: '/about/data-quality',
-      fr: '/apropos/qualite-donnees'
+      fr: '/a-propos/qualite-donnees'
     }
   }
 }

--- a/pages/about/faq.vue
+++ b/pages/about/faq.vue
@@ -2,78 +2,52 @@
   <v-layout justify-center column align-content-center>
     <h1>{{ $t('about.faq.title') }}</h1>
     <p>{{ $t('about.faq.blurb') }}</p>
-    <div v-for="(question, i) in questions" :key="i">
-      <h4>{{ question.text }}</h4>
-      <woudc-blurb :items="question.answer" />
+    <div v-for="index in $t('about.faq.questions').length" :key="index">
+      <h4 v-text="$t('about.faq.questions[' + (index - 1) + '].text')" />
+      <i18n :path="'about.faq.questions[' + (index - 1) + '].answer'" tag="p">
+        <template v-slot:policy>
+          <nuxt-link :to="localePath('about-datapolicy')" v-text="$t('about.faq.substitutions.policy')" />
+        </template>
+        <template v-slot:submission>
+          <nuxt-link :to="localePath('contributors-submission')" v-text="$t('about.faq.substitutions.submission')" />
+        </template>
+        <template v-slot:registration>
+          <nuxt-link :to="localePath('contributors-registration')" v-text="$t('about.faq.substitutions.registration')" />
+        </template>
+        <template v-slot:access>
+          <nuxt-link :to="localePath('about-dataaccess')" v-text="$t('about.faq.substitutions.access')" />
+        </template>
+        <template v-slot:search>
+          <nuxt-link :to="localePath('data-explore')" v-text="$t('about.faq.substitutions.search')" />
+        </template>
+        <template v-slot:products>
+          <nuxt-link :to="localePath('data-products')" v-text="$t('about.faq.substitutions.products')" />
+        </template>
+        <template v-slot:contributors>
+          <nuxt-link :to="localePath('contributors')" v-text="$t('about.faq.substitutions.contributors')" />
+        </template>
+        <template v-slot:accessibility>
+          <a :href="accessibilityURL" target="_blank" v-text="$t('about.faq.substitutions.accessibility')" />
+        </template>
+        <template v-slot:usability>
+          <a :href="usabilityURL" target="_blank" v-text="$t('about.faq.substitutions.usability')" />
+        </template>
+        <template v-slot:w3c>
+          <a :href="w3cURL" target="_blank" v-text="$t('about.faq.substitutions.w3c')" />
+        </template>
+      </i18n>
     </div>
   </v-layout>
 </template>
 
 <script>
-import WoudcBlurb from '~/components/WoudcBlurb'
-
-function makeLink(text, to, external) {
-  const link = { text, to }
-  if (external) {
-    link.type = 'external'
-  }
-
-  return { link }
-}
-
-
 export default {
-  components: {
-    'woudc-blurb': WoudcBlurb
-  },
   data() {
-    // (Deep-ish) copy list of questions from translations.
-    const questions = this.$t('about.faq.questions').map((entry) => {
-      return {
-        text: entry.text,
-        answer: Array.isArray(entry.answer) ? [...entry.answer] : entry.answer
-      }
-    })
-
-    // Add parts of the answer text that are independent of language
-    // (e.g. some link endpoints)
-    questions[0].answer[1] = makeLink(questions[0].answer[1], 'about-datapolicy', false)
-    questions[0].answer.push('.')
-
-    questions[1].answer[1] = makeLink(questions[1].answer[1], 'contributors-submission', false)
-    questions[1].answer[3] = makeLink(questions[1].answer[3], 'contributors-registration', false)
-    questions[1].answer.push('.')
-
-    questions[2].answer[1] = makeLink(questions[2].answer[1], 'about-dataaccess', false)
-
-    questions[3].answer[1] = makeLink(questions[3].answer[1], 'data-explore', false)
-    questions[3].answer[3] = makeLink(questions[3].answer[3], 'data-products', false)
-
-    questions[4].answer[1] = makeLink(questions[4].answer[1], 'contributors', false)
-    questions[4].answer.push('.')
-
-    questions[7].answer[1] = makeLink(questions[7].answer[1], 'about-dataaccess', false)
-
-    questions[8].answer[1] = makeLink(
-      questions[8].answer[1],
-      'https://www.tbs-sct.gc.ca/ws-nw/wa-aw/index-eng.asp',
-      true
-    )
-    questions[8].answer[3] = makeLink(
-      questions[8].answer[3],
-      'https://www.tbs-sct.gc.ca/ws-nw/wu-fe/index-eng.asp',
-      true
-    )
-    questions[8].answer[5] = {
-      italic: makeLink(
-        questions[8].answer[5],
-        'https://www.w3.org/WAI/intro/wcag',
-        true
-      )
+    return {
+      accessibilityURL: 'https://www.tbs-sct.gc.ca/ws-nw/wa-aw/index-eng.asp',
+      usabilityURL: 'https://www.tbs-sct.gc.ca/ws-nw/wu-fe/index-eng.asp',
+      w3cURL: 'https://www.w3.org/WAI/intro/wcag'
     }
-    questions[8].answer.push('.')
-
-    return { questions }
   },
   nuxtI18n: {
     paths: {

--- a/pages/about/faq.vue
+++ b/pages/about/faq.vue
@@ -51,8 +51,8 @@ export default {
   },
   nuxtI18n: {
     paths: {
-      en: '/faq',
-      fr: '/faq-in-fr'
+      en: '/about/faq',
+      fr: '/a-propos/faq'
     }
   }
 }

--- a/pages/about/formats.vue
+++ b/pages/about/formats.vue
@@ -1,44 +1,41 @@
 <template>
   <v-layout justify-center column align-content-center>
-    <h1>{{ $t('about.formats.title') }}</h1>
-    <woudc-blurb :items="mainBlurb" />
-    <woudc-note :body="$t('about.formats.note')" />
-    <h2>{{ $t('about.formats.contributor-guide.title') }}</h2>
+    <h1 v-text="$t('about.formats.title')" />
+    <i18n class="newlines" path="about.formats.blurb.template" tag="p">
+      <template v-slot:extended>
+        <b v-text="$t('about.formats.blurb.extended')" />
+      </template>
+      <template v-slot:access>
+        <nuxt-link :to="localePath('about-dataaccess')" v-text="$t('about.formats.blurb.access')" />
+      </template>
+    </i18n>
+    <v-card class="woudc-note" tile min-width="0px">
+      <v-card-text v-text="$t('about.formats.note')" />
+    </v-card>
+    <h2 v-text="$t('about.formats.contributor-guide.title')" />
     <ul>
-      <li v-for="(link, i) in contributorLinks" :key="i">
-        <a :href="link.url">
-          {{ link.text }}
-        </a>
+      <li>
+        <a :href="contributorsURL" v-text="$t('about.formats.contributor-guide.link')" />
       </li>
     </ul>
-    <h2>{{ $t('about.formats.examples.title') }}</h2>
-    <p>{{ $t('about.formats.examples.blurb') }}</p>
-    <h2>{{ $t('about.formats.ozone.title') }}</h2>
+    <h2 v-text="$t('about.formats.examples.title')" />
+    <p v-text="$t('about.formats.examples.blurb')" />
+    <h3 v-text="$t('about.formats.ozone.title')" />
     <ul>
       <li v-for="(link, i) in ozoneLinks" :key="i">
-        <a :href="link.url">
-          {{ link.text }}
-        </a>
+        <a :href="link.url" v-text="link.text" />
       </li>
     </ul>
-    <h2>{{ $t('about.formats.uv.title') }}</h2>
+    <h3 v-text="$t('about.formats.uv.title')" />
     <ul>
       <li v-for="(link, i) in uvLinks" :key="i">
-        <a :href="link.url">
-          {{ link.text }}
-        </a>
+        <a :href="link.url" v-text="link.text" />
       </li>
     </ul>
   </v-layout>
 </template>
 
 <script>
-import WoudcBlurb from '~/components/WoudcBlurb'
-import WoudcNote from '~/components/WoudcNote'
-
-const contributorURLs = [
-  'https://guide.woudc.org/en/'
-]
 const ozoneURLs = [
   'https://woudc.org/archive/Documentation/Examples-extCSV/Lidar.csv',
   'https://woudc.org/archive/Documentation/Examples-extCSV/Ozonesonde.csv',
@@ -54,36 +51,22 @@ const uvURLs = [
 ]
 
 export default {
-  components: {
-    'woudc-blurb': WoudcBlurb,
-    'woudc-note': WoudcNote
-  },
   data() {
     return {
-      contributorLinks: [...contributorURLs.keys()].map((index) => {
-        return {
-          text: this.$t('about.formats.contributor-guide.links[' + index + ']'),
-          url: contributorURLs[index]
-        }
-      }),
-      mainBlurb: [
-        { text: this.$t('about.formats.blurb[0]') },
-        { bold: this.$t('about.formats.extended') },
-        { text: this.$t('about.formats.blurb[1]') },
-        { newlines: 2 },
-        { text: this.$t('about.formats.blurb[2]') },
-        { bold: this.$t('about.formats.extended') },
-        { text: this.$t('about.formats.blurb[3]') },
-        { link: { to: 'about-dataaccess', text: this.$t('about.formats.blurb[4]') } },
-        { text: this.$t('about.formats.blurb[5]') }
-      ],
-      ozoneLinks: [...ozoneURLs.keys()].map((index) => {
+      contributorsURL: 'https://guide.woudc.org/en/'
+    }
+  },
+  computed: {
+    ozoneLinks() {
+      return [...ozoneURLs.keys()].map((index) => {
         return {
           text: this.$t('about.formats.ozone.links[' + index + ']'),
           url: ozoneURLs[index]
         }
-      }),
-      uvLinks: [...uvURLs.keys()].map((index) => {
+      })
+    },
+    uvLinks() {
+      return [...uvURLs.keys()].map((index) => {
         return {
           text: this.$t('about.formats.uv.links[' + index + ']'),
           url: uvURLs[index]

--- a/pages/about/formats.vue
+++ b/pages/about/formats.vue
@@ -36,40 +36,39 @@
 </template>
 
 <script>
-const ozoneURLs = [
-  'https://woudc.org/archive/Documentation/Examples-extCSV/Lidar.csv',
-  'https://woudc.org/archive/Documentation/Examples-extCSV/Ozonesonde.csv',
-  'https://woudc.org/archive/Documentation/Examples-extCSV/TotalOzone-Brewer.csv',
-  'https://woudc.org/archive/Documentation/Examples-extCSV/TotalOzoneObs.csv',
-  'https://woudc.org/archive/Documentation/Examples-extCSV/Umkehr-N_values-Dobson.csv',
-  'https://woudc.org/archive/Documentation/Examples-extCSV/Umkehr_UMK92Retrieval-Dobson.csv'
-]
-const uvURLs = [
-  'https://woudc.org/archive/Documentation/Examples-extCSV/Broad-band.csv',
-  'https://woudc.org/archive/Documentation/Examples-extCSV/Multi-band.csv',
-  'https://woudc.org/archive/Documentation/Examples-extCSV/Spectral.csv'
-]
-
 export default {
   data() {
     return {
-      contributorsURL: 'https://guide.woudc.org/en/'
+      contributorsURL: 'https://guide.woudc.org/en/',
+      ozoneURLs: [
+        'https://woudc.org/archive/Documentation/Examples-extCSV/Lidar.csv',
+        'https://woudc.org/archive/Documentation/Examples-extCSV/Ozonesonde.csv',
+        'https://woudc.org/archive/Documentation/Examples-extCSV/TotalOzone-Brewer.csv',
+        'https://woudc.org/archive/Documentation/Examples-extCSV/TotalOzoneObs.csv',
+        'https://woudc.org/archive/Documentation/Examples-extCSV/Umkehr-N_values-Dobson.csv',
+        'https://woudc.org/archive/Documentation/Examples-extCSV/Umkehr_UMK92Retrieval-Dobson.csv'
+      ],
+      uvURLs: [
+        'https://woudc.org/archive/Documentation/Examples-extCSV/Broad-band.csv',
+        'https://woudc.org/archive/Documentation/Examples-extCSV/Multi-band.csv',
+        'https://woudc.org/archive/Documentation/Examples-extCSV/Spectral.csv'
+      ]
     }
   },
   computed: {
     ozoneLinks() {
-      return [...ozoneURLs.keys()].map((index) => {
+      return [...this.ozoneURLs.keys()].map((index) => {
         return {
           text: this.$t('about.formats.ozone.links[' + index + ']'),
-          url: ozoneURLs[index]
+          url: this.ozoneURLs[index]
         }
       })
     },
     uvLinks() {
-      return [...uvURLs.keys()].map((index) => {
+      return [...this.uvURLs.keys()].map((index) => {
         return {
           text: this.$t('about.formats.uv.links[' + index + ']'),
-          url: uvURLs[index]
+          url: this.uvURLs[index]
         }
       })
     }

--- a/pages/about/formats.vue
+++ b/pages/about/formats.vue
@@ -75,8 +75,8 @@ export default {
   },
   nuxtI18n: {
     paths: {
-      en: '/formats',
-      fr: '/formats'
+      en: '/about/formats',
+      fr: '/a-propos/formats'
     }
   }
 }

--- a/pages/about/glossary.vue
+++ b/pages/about/glossary.vue
@@ -1,24 +1,34 @@
 <template>
   <v-layout justify-center column align-content-center>
-    <h1>{{ $t('about.glossary.title') }}</h1>
-    <p>{{ $t('about.glossary.blurb') }}</p>
-    <div v-for="(entry, i) in terms" :key="i">
-      <h4>{{ entry.term }}</h4>
-      <woudc-blurb :items="entry.definition" />
+    <h1 v-text="$t('about.glossary.title')" />
+    <p v-text="$t('about.glossary.blurb')" />
+    <div v-for="(_, index) in $t('about.glossary.terms').length" :key="index">
+      <h4 v-text="$t('about.glossary.terms[' + index + '].term')" />
+      <i18n :path="'about.glossary.terms[' + index + '].definition'" tag="p">
+        <template v-slot:carcinogenesis>
+          <a :href="carcinogensURL" target="_blank" v-text="$t('about.glossary.substitutions.carcinogenesis')" />
+        </template>
+        <template v-slot:registration>
+          <nuxt-link :to="localePath('contributors-registration')" v-text="$t('about.glossary.substitutions.registration')" />
+        </template>
+        <template v-slot:w3>
+          <a :href="w3URL" target="_blank">www.w3.org</a>
+        </template>
+        <template v-slot:waf>
+          <a :href="wafURL" target="_blank" v-text="wafURL" />
+        </template>
+      </i18n>
     </div>
   </v-layout>
 </template>
 
 <script>
-import WoudcBlurb from '~/components/WoudcBlurb'
-
 export default {
-  components: {
-    'woudc-blurb': WoudcBlurb
-  },
-  computed: {
-    terms() {
-      return this.$t('about.glossary.terms')
+  data() {
+    return {
+      carcinogensURL: 'https://www.wmo.int/pages/prog/dra/etrp/documents/926E.pdf',
+      w3URL: 'https://www.w3.org/',
+      wafURL: "https://woudc.org/archive"
     }
   },
   nuxtI18n: {

--- a/pages/about/glossary.vue
+++ b/pages/about/glossary.vue
@@ -33,8 +33,8 @@ export default {
   },
   nuxtI18n: {
     paths: {
-      en: '/glossary',
-      fr: '/glossaire'
+      en: '/about/glossary',
+      fr: '/a-propos/glossaire'
     }
   }
 }

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -48,8 +48,7 @@ export default {
         {
           hid: 'description',
           name: 'description',
-          content:
-            'The World Ozone and Ultraviolet Radiation Data Centre (WOUDC) is one of six World Data Centres which are part of the Global Atmosphere Watch programme of the World Meteorological Organization. The WOUDC data centre is operated by the Meteorological Service of Canada, a branch of Environment and Climate Change Canada.'
+          content: 'The World Ozone and Ultraviolet Radiation Data Centre (WOUDC) is one of six World Data Centres which are part of the Global Atmosphere Watch programme of the World Meteorological Organization. The WOUDC data centre is operated by the Meteorological Service of Canada, a branch of Environment and Climate Change Canada.'
         }
       ]
     }

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -1,8 +1,20 @@
 <template>
   <v-layout justify-center column align-content-center>
-    <h2>{{ $t('about.home.title') }}</h2>
-    <woudc-blurb :items="blurb" />
-
+    <h2 v-text="$t('about.home.title')" />
+    <i18n class="newlines" path="about.home.blurb.template" tag="p">
+      <template v-slot:stations>
+        <nuxt-link :to="localePath('data-stations')" v-text="$t('about.home.blurb.stations')" />
+      </template>
+      <template v-slot:contributors>
+        <nuxt-link :to="localePath('contributors')" v-text="$t('about.home.blurb.contributors')" />
+      </template>
+      <template v-slot:search>
+        <nuxt-link :to="localePath('data-explore')" v-text="$t('about.home.blurb.search')" />
+      </template>
+      <template v-slot:access>
+        <nuxt-link :to="localePath('about-dataaccess')" v-text="$t('about.home.blurb.access')" />
+      </template>
+    </i18n>
     <v-card
       id="history"
       itemprop="hasPart"
@@ -14,13 +26,12 @@
       </v-card-title>
       <v-list itemprop="about" itemscope itemtype="http://schema.org/ItemList">
         <v-list-item
-          v-for="(milestone, i) in milestones"
+          v-for="(event, year, i) in $t('about.home.history.milestones')"
           :key="i"
           itemprop="itemListElement"
         >
           <span>
-            <b>{{ milestone.year }}</b>
-            : {{ milestone.text }}
+            <b>{{ year }}</b> : {{ event }}
           </span>
         </v-list-item>
       </v-list>
@@ -29,43 +40,7 @@
 </template>
 
 <script>
-import WoudcBlurb from '~/components/WoudcBlurb'
-
-const years = [ 1960, 1964, 1992, 1995, 1996, 2006, 2015 ]
-
 export default {
-  components: {
-    'woudc-blurb': WoudcBlurb
-  },
-  data() {
-    return {
-      blurb: [
-        { text: this.$t('about.home.blurb[0]') },
-        { newlines: 2 },
-        { text: this.$t('about.home.blurb[1]') },
-        { newlines: 2 },
-        { text: this.$t('about.home.blurb[2]') },
-        { link: { to: 'data-stations', text: this.$t('about.home.blurb[3]') } },
-        { text: this.$t('about.home.blurb[4]') },
-        { link: { to: 'contributors', text: this.$t('about.home.blurb[5]') } },
-        { text: this.$t('about.home.blurb[6]') },
-        { newlines: 2 },
-        { text: this.$t('about.home.blurb[7]') },
-        { newlines: 2 },
-        { text: this.$t('about.home.blurb[8]') },
-        { link: { to: 'data-explore', text: this.$t('about.home.blurb[9]') } },
-        { text: this.$t('about.home.blurb[10]') },
-        { link: { to: 'about-dataaccess', text: this.$t('about.home.blurb[11]') } },
-        { text: this.$t('about.home.blurb[12]') },
-      ],
-      milestones: [...years.keys()].map((index) => {
-        return {
-          year: years[index],
-          text: this.$t('about.home.history.milestones[' + index + ']')
-        }
-      })
-    }
-  },
   head() {
     return {
       title: this.$t('about.home.title'),

--- a/pages/about/standards.vue
+++ b/pages/about/standards.vue
@@ -18,12 +18,12 @@
     >
       <template v-slot:item.formats="props">
         <v-chip v-for="link in props.item.formats" :key="link.to" class="resource" label>
-          <a :href="link.to" v-text="link.text" />
+          <a :href="link.to" target="_blank" v-text="link.text" />
         </v-chip>
       </template>
       <template v-slot:item.services="props">
         <v-chip v-for="link in props.item.services" :key="link.to" class="resource" label>
-          <a :href="link.to" v-text="link.text" />
+          <a :href="link.to" target="_blank" v-text="link.text" />
         </v-chip>
       </template>
     </v-data-table>
@@ -50,6 +50,7 @@ export default {
       },
       serviceURLs: {
         csw: 'https://www.opengeospatial.org/standards/cat',
+        opensearch: 'https://github.com/dewitt/opensearch',
         pmh: 'https://www.openarchives.org/pmh/',
         wfs: 'https://www.opengeospatial.org/standards/wfs',
         wms: 'https://www.opengeospatial.org/standards/wms'

--- a/pages/about/standards.vue
+++ b/pages/about/standards.vue
@@ -110,7 +110,7 @@ export default {
   nuxtI18n: {
     paths: {
       en: '/about/standards',
-      fr: '/apropos/normes'
+      fr: '/a-propos/normes'
     }
   }
 }


### PR DESCRIPTION
First of two pull requests that removes all occurrences of the woudc-blurb, woudc-note, and woudc-link components and replaces them with straight-up Vue components in the About section of pages.

Mainly affects the remaining pages after the first pull request, namely the root About page, file formats, glossary, and FAQ, though it also makes some small changes like routes among the other pages.

Intended as part of a cleanup of the translation system, so that blurbs are built using readable component substitution rather than being set up behind-the-scenes by all these custom components. So translations in the JSON files and their uses in the Vue components have been cleaned up in the four About section pages.