### PR TITLE
Unpack Components - Static Pages

### DIFF
--- a/css/globals.css
+++ b/css/globals.css
@@ -1,0 +1,3 @@
+.newlines {
+  white-space: pre-line;
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -865,65 +865,47 @@
       "title": "Contributor List"
     },
     "registration": {
-      "blurb1": [
-        "All new data contributors require a WOUDC account. All account applications are subject to review by the WOUDC personnel. WOUDC reserves the right to evaluate all applications for data submission for compliance with the World Meteorological Organization (WMO) Global Atmosphere Watch (GAW) data exchange protocols.",
-        "Contributors of new data are asked to follow the steps below for arranging ",
-        "data submissions",
-        " to WOUDC for ozone and/or ultraviolet radiation data sets:"
-      ],
-      "blurb2": [
-        "Thank you for registering with WOUDC."
-      ],
-      "step1": [
-        "Review the WOUDC ",
-        "data policy"
-      ],
-      "step2": [
-        "Obtain a GAW ID (required) for each station by registering with ",
-        "WMO/GAW",
-        "more about GAW"
-      ],
-      "step3": [
-        "Complete the WOUDC registration process by ",
-        "contacting WOUDC",
-        " with the subject line: ",
-        "new registration",
-        " and include your new GAW ID; and"
-      ],
-      "step4": [
-        "Upon receipt and approval of your registration, the WOUDC will assign an FTP location / account (with a personal username/password) to be used exclusively for data submission."
-      ],
+      "blurb1": {
+        "submission": "data submissions",
+        "template": "All new data contributors require a WOUDC account. All account applications are subject to review by the WOUDC personnel. WOUDC reserves the right to evaluate all applications for data submission for compliance with the World Meteorological Organization (WMO) Global Atmosphere Watch (GAW) data exchange protocols.\n\nContributors of new data are asked to follow the steps below for arranging {submission} to WOUDC for ozone and/or ultraviolet radiation data sets:"
+      },
+      "blurb2": "Thank you for registering with WOUDC.",
+      "step1": {
+        "policy": "data policy",
+        "template": "Review the WOUDC {policy};"
+      },
+      "step2": {
+        "more": "more about GAW",
+        "template": "Obtain a GAW ID (required) for each station by registering with {wmo} ({more});",
+        "wmo": "WMO/GAW"
+      },
+      "step3": {
+        "contact": "contacting WOUDC",
+        "register": "new registration",
+        "template": "Complete the WOUDC registration process by {contact} with the subject line: {register} and include your new GAW ID; and"
+      },
+      "step4": "Upon receipt and approval of your registration, the WOUDC will assign an FTP location / account (with a personal username/password) to be used exclusively for data submission.",
       "title": "Registration"
     },
     "submission": {
-      "blurb1": [
-        "The WOUDC processes data on a daily basis for near real-time data submissions. Registered contributors can submit data to the WOUDC via FTP."
-      ],
-      "blurb2": [
-        "It is recommended that data be submitted at least once a month. Please ",
-        "contact us",
-        " for further information"
-      ],
+      "blurb1": "The WOUDC processes data on a daily basis for near real-time data submissions. Registered contributors can submit data to the WOUDC via FTP.",
+      "blurb2": {
+        "contact": "contact us",
+        "template": "It is recommended that data be submitted at least once a month. Please {contact} for further information"
+      },
       "note1": "files cannot be updated after they are transferred to the WOUDC. To submit updated data files, transfer again using a different file name.",
       "note2": "step details may vary depending on your computer system and FTP software.",
-      "step1": [
-        "Data files can be sent individually or packaged into .zip, .tar, or .tar.gz format. See ",
-        "File Formats",
-        " for more information"
-      ],
-      "step2": [
-        "Using an FTP client, connect to the ",
-        "WOUDC FTP server"
-      ],
-      "step3": [
-        "Log in with your pre-assigned username and password"
-      ],
-      "step4": [
-        "Each contributor transfers their respective files to their individual folder on the FTP site (files cannot be updated after transfer to WOUDC. To submit updated data files, they must be transferred again, using a different file name)"
-      ],
-      "step5": [
-        "Log out to end the FTP session"
-      ],
+      "step1": {
+        "formats": "File Formats",
+        "template": "Data files can be sent individually or packaged into .zip, .tar, or .tar.gz format. See {formats} for more information"
+      },
+      "step2": {
+        "ftp": "WOUDC FTP server",
+        "template": "Using an FTP client, connect to the {ftp}"
+      },
+      "step3": "Log in with your pre-assigned username and password",
+      "step4": "Each contributor transfers their respective files to their individual folder on the FTP site (files cannot be updated after transfer to WOUDC. To submit updated data files, they must be transferred again, using a different file name)",
+      "step5": "Log out to end the FTP session",
       "subtitle": "Data Submission Steps",
       "title": "Data Submission"
     },
@@ -933,13 +915,13 @@
     }
   },
   "data": {
-    "links": [
-      "Data Search / Download",
-      "Data Products",
-      "Dataset Information",
-      "Station List",
-      "Instrument List"
-    ],
+    "links": {
+      "datasetinfo": "Dataset Information",
+      "explore": "Data Search / Download",
+      "instruments": "Instrument List",
+      "products": "Data Products",
+      "stations": "Station List"
+    },
     "title": "Data",
     "explore": {
       "blurb": [
@@ -966,31 +948,25 @@
     "info": {
       "blurb": "The WOUDC data archive can provide high level information about each dataset. Select a dataset of interest to see its ISO discovery metadata and a contextual map of the stations.",
       "sections": {
-        "total-ozone": {
-          "links": [
-            "Total Ozone - Daily Observations",
-            "Total Ozone - Hourly Observations"
-          ],
+        "totalozone": {
+          "daily": "Total Ozone - Daily Observations",
+          "hourly": "Total Ozone - Hourly Observations",
           "title": "Total Column Ozone"
         },
         "vertical-ozone": {
-          "links": [
-            "Lidar",
-            "OzoneSonde",
-            "UmkehrN14 (Level 1.0)",
-            "UmkehrN14 (Level 2.0)",
-            "RocketSonde"
-          ],
-          "title": "Vertical Ozone Profile"
+          "lidar": "Lidar",
+          "ozonesonde": "OzoneSonde",
+          "rocketsonde": "RocketSonde",
+          "title": "Vertical Ozone Profile",
+          "umkehr1": "UmkehrN14 (Level 1.0)",
+          "umkehr2": "UmkehrN14 (Level 2.0)"
         },
         "uv-irradiance": {
-          "links": [
-            "Broadband",
-            "Multiband",
-            "Spectral",
-            "UV Index"
-          ],
-          "title": "UV Irradiance"
+          "broadband": "Broadband",
+          "multiband": "Multiband",
+          "spectral": "Spectral",
+          "title": "UV Irradiance",
+          "uv-index": "UV Index"
         }
       },
       "subtitle": "Dataset",
@@ -1022,46 +998,44 @@
       "blurb": "Special output data products are prepared by the WOUDC to assist researchers and provide value added information; some of the data products include total column ozone time series graphs and near real-time ozone maps.",
       "maps": {
         "blurb": "Near-real time, global total ozone maps, normally updated daily at approximately 1400 UTC.",
-        "links": [
-          "Most Recent Global Total Ozone Maps",
-          "Ozone Maps for the Northern Hemisphere",
-          "Ozone Maps for the Southern Hemisphere",
-          "Ozone Map Archive",
-          "Recent Ozone Maps Individual Data Sources and Ozone Forecast Maps"
-        ],
+        "links": {
+          "archive": "Ozone Map Archive",
+          "global": "Most Recent Global Total Ozone Maps",
+          "individual": "Recent Ozone Maps Individual Data Sources and Ozone Forecast Maps",
+          "north": "Ozone Maps for the Northern Hemisphere",
+          "south": "Ozone Maps for the Southern Hemisphere"
+        },
         "title": "Ozone Maps"
       },
       "related": {
-        "blurb": "_",
-        "links": [
-          "Total Ozone Summary Data: Daily and Monthly Means",
-          "Satellite versus Ground-based Total Ozone Comparison Results",
-          "Umkehr Data by Algorithm",
-          "Spectral UV Monthly Summaries and Plots",
-          "Zonal Mean Ozone from Ground-Based Instruments",
-          "Trajectory-mapped Ozonesonde dataset for the Stratosphere and Troposphere (TOST)"
-        ],
+        "links": {
+          "ozone-zonal": "Zonal Mean Ozone from Ground-Based Instruments",
+          "spectral": "Spectral UV Monthly Summaries and Plots",
+          "tost": "Trajectory-mapped Ozonesonde dataset for the Stratosphere and Troposphere (TOST)",
+          "totalozone-daily-monthly": "Total Ozone Summary Data: Daily and Monthly Means",
+          "totalozone-satellite-ground": "Satellite versus Ground-based Total Ozone Comparison Results",
+          "umkehr": "Umkehr Data by Algorithm"
+        },
         "title": "Related Ozone Products"
       },
       "summaries": {
-        "blurb": "_",
-        "links": [
-          "Antarctic and Arctic ozone bulletins - WMO",
-          "GAW Research and Monitoring Reports - WMO",
-          "Global Ozone Research and Monitoring Project Reports - WMO",
-          "Ozone Hole Watch - NASA",
-          "Satellite Measurements from Polar Orbit - FMI",
-          "Tropospheric Emission Monitoring Internet Service"
-        ],
+        "links": {
+          "gaw-reports": "GAW Research and Monitoring Reports - WMO",
+          "ozone-hole": "Ozone Hole Watch - NASA",
+          "ozone-reports": "Global Ozone Research and Monitoring Project Reports - WMO",
+          "polar-bulletins": "Antarctic and Arctic ozone bulletins - WMO",
+          "sampo": "Satellite Measurements from Polar Orbit - FMI",
+          "temis": "Tropospheric Emission Monitoring Internet Service"
+        },
         "title": "Data Summaries and Reports"
       },
       "time-series": {
         "blurb": "A variety of plots are available which can be used, for example, to check the data availability.",
-        "links": [
-          "Ozonesonde plots",
-          "Total Ozone plots",
-          "UV index plots"
-        ],
+        "links": {
+          "ozonesonde": "Ozonesonde plots",
+          "totalozone": "Total Ozone plots",
+          "uv-index": "UV index plots"
+        },
         "title": "Time Series Graphs"
       },
       "title": "Data Products"
@@ -1110,7 +1084,7 @@
   "home": {
     "aboutWoudc": "About WOUDC",
     "adTitle": "Discover, Visualize and Access a Global Archive of Ground-based Ozone and UV Radiation Data",
-    "description": "",
+    "blurb": "A World Meteorological Organization ({wmo}) data center supporting the Global Atmosphere Watch ({gaw}) program operated by Environment and Climate Change Canada.",
     "gawLogo": "Logo: @.gawFull",
     "learnMore": "Learn more",
     "wmoLogo": "Logo: @.wmoFull"
@@ -1120,20 +1094,20 @@
     "blurb": "Data centre news, updates and notifications"
   },
   "resources": {
-    "links": [
-      "Standard Operating Procedures",
-      "Working Groups",
-      "Related Data Links",
-      "Software"
-    ],
+    "links": {
+      "links": "Related Data Links",
+      "software": "Software",
+      "sop": "Standard Operating Procedures",
+      "workinggroups": "Working Groups"
+    },
     "title": "Resources",
     "procedures": {
       "blurb": "Links to Standard Operating Procedures (SOP) related to Ozone and UV Radiation data.",
-      "headers": [
-        "Category",
-        "SOP",
-        "Source"
-      ],
+      "headers": {
+        "category": "Category",
+        "link": "SOP",
+        "source": "Source"
+      },
       "rows": [
         {
           "category": "Brewer SOP",
@@ -1169,38 +1143,36 @@
       "title": "Standard Operating Procedures"
     },
     "related-links": {
+      "links": {
+        "avdc": "Aura Validation Data Center (AVDC) - NASA",
+        "crdp": "Climate Research Data Package (CRDP) - ESA",
+        "esrl": "Earth System Research Laboratory/Global Monitoring Division (ESRL/GMD) - NOAA",
+        "eubrewnet": "European Brewer Network (EUBREWNET)",
+        "euvdb": "European UV Database (EUVDB)",
+        "gawsis": "GAW Station Information System (GAWSIS)",
+        "gozcards": "Global OZone Chemistry And Related trace gas Data records for the Stratosphere (GOZCARDS) - NASA",
+        "mozaic": "MOZAIC/IAGOS Database ",
+        "ndacc": "Network for the Detection of Atmospheric Composition Change (NDACC) - NOAA",
+        "oscar": "Observing Systems Capability Analysis and Review Tool (OSCAR)",
+        "polar": "NSF Polar Programs UV Monitoring Network",
+        "projects": "Projects and Campaigns",
+        "shadoz": "Southern Hemisphere Additional Ozonesondes (SHADOZ) - NASA",
+        "uvi": "Polar/UVI Data Archives - NASA",
+        "wdc-aerosol": "World Data Centre for Aerosols",
+        "wdc-ghg": "World Data Centre for Greenhouse Gases",
+        "wdc-precip": "World Data Centre for Precipitation Chemistry",
+        "wdc-sensing": "World Data Center for Remote Sensing of the Atmosphere",
+        "wrdc": "World Radiation Data Centre"
+      },
       "other-title": "Other Related Data",
-      "other-links": [
-        "Aura Validation Data Center (AVDC) - NASA",
-        "Climate Research Data Package (CRDP) - ESA",
-        "Earth System Research Laboratory/Global Monitoring Division (ESRL/GMD) - NOAA",
-        "European Brewer Network (EUBREWNET)",
-        "European UV Database (EUVDB)",
-        "Global OZone Chemistry And Related trace gas Data records for the Stratosphere (GOZCARDS) - NASA",
-        "MOZAIC/IAGOS Database ",
-        "Network for the Detection of Atmospheric Composition Change (NDACC) - NOAA",
-        "NSF Polar Programs UV Monitoring Network",
-        "Polar/UVI Data Archives - NASA",
-        "Southern Hemisphere Additional Ozonesondes (SHADOZ) - NASA"
-      ],
-      "wmo-links": [
-        "GAW Station Information System (GAWSIS)",
-        "Observing Systems Capability Analysis and Review Tool (OSCAR)",
-        "Projects and Campaigns",
-        "World Data Centre for Aerosols",
-        "World Data Centre for Greenhouse Gases",
-        "World Data Centre for Precipitation Chemistry",
-        "World Data Center for Remote Sensing of the Atmosphere",
-        "World Radiation Data Centre"
-      ],
       "title": "Related Data Links"
     },
     "working-groups": {
-      "links": [
-        "Brewer User Group",
-        "Dobson Ad-Hoc Committee",
-        "Umkehr Sub-Committee"
-      ],
+      "links": {
+        "brewer": "Brewer User Group",
+        "dobson": "Dobson Ad-Hoc Committee",
+        "umkehr": "Umkehr Sub-Committee"
+      },
       "title": "Working Groups"
     }
   }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -870,63 +870,45 @@
       "title": "Liste des contributeurs"
     },
     "registration": {
-      "blurb1": [
-        "Tous les nouveaux contributeurs aux données doivent posséder un compte WOUDC. Toutes les demandes pour la création de nouveaux comptes devront être vérifiées par le personnel du WOUDC. Le WOUDC se réserve le droit de vérifier toutes les demandes de soumission de données afin de s’assurer qu’elles soient conformes avec les protocoles d’échange de données du programme de Veille de l’atmosphère du globe (VAG) de l’Organisation météorologique mondiale (OMM).",
-        "Les contributeurs qui désirent soumettre de nouvelles données doivent suivre les étapes suivantes afin d’organiser ",
-        "les soumissions de données",
-        " au WOUDC en ensembles de données sur l’ozone ou le rayonnement ultraviolet :"
-      ],
-      "blurb2": [
-        "Nous vous remercions de votre inscription au WOUDC."
-      ],
-      "step1": [
-        "Lire la politique du WOUDC ",
-        "relative aux données"
-      ],
-      "step2": [
-        "Obtenir un identifiant VAG (obligatoire) pour chacune des stations en s’inscrivant avec ",
-        "OMM/VAG",
-        "En savoir plus sur la VAG"
-      ],
-      "step3": [
-        "Compléter le processus d'enregistrement de WOUDC en ",
-        "contactant WOUDC",
-        " avec comme titre : ",
-        "nouvelle inscription",
-        "et inclut votre nouvel identifiant VAG ; et"
-      ],
-      "step4": [
-        "Après réception et approbation de votre inscription, le WOUDC attribuera un emplacement FTP / compte FTP (avec un nom d'utilisateur / mot de passe personnel) à utiliser exclusivement pour la soumission des données."
-      ],
+      "blurb1": {
+        "submission": "les soumissions de données",
+        "template": "Tous les nouveaux contributeurs aux données doivent posséder un compte WOUDC. Toutes les demandes pour la création de nouveaux comptes devront être vérifiées par le personnel du WOUDC. Le WOUDC se réserve le droit de vérifier toutes les demandes de soumission de données afin de s’assurer qu’elles soient conformes avec les protocoles d’échange de données du programme de Veille de l’atmosphère du globe (VAG) de l’Organisation météorologique mondiale (OMM).\n\nLes contributeurs qui désirent soumettre de nouvelles données doivent suivre les étapes suivantes afin d’organiser {submission} au WOUDC en ensembles de données sur l’ozone ou le rayonnement ultraviolet :"
+      },
+      "blurb2": "Nous vous remercions de votre inscription au WOUDC.",
+      "step1": {
+        "policy": "relative aux données",
+        "template": "Lire la politique du WOUDC {policy};"
+      },
+      "step2": {
+        "more": "En savoir plus sur la VAG",
+        "template": "Obtenir un identifiant VAG (obligatoire) pour chacune des stations en s’inscrivant avec {wmo} ({more});",
+        "wmo": "OMM/VAG"
+      },
+      "step3": {
+        "contact": "contactant WOUDC",
+        "register": "nouvelle inscription",
+        "template": "Compléter le processus d'enregistrement de WOUDC en {contact} avec comme titre : {register} et inclut votre nouvel identifiant VAG ; et"
+      },
+      "step4": "Après réception et approbation de votre inscription, le WOUDC attribuera un emplacement FTP / compte FTP (avec un nom d'utilisateur / mot de passe personnel) à utiliser exclusivement pour la soumission des données.",
       "title": "Inscription"
     },
     "submission": {
-      "blurb1": [
-        "Le WOUDC traite les données de façon quotidienne afin que les soumissions de données soient complétées pratiquement en temps réel. Les contributeurs inscrits peuvent soumettre des données1 au WOUDC via le serveur FTP."
-      ],
-      "blurb2": [
-        "Il est recommandé de soumettre les données au moins une fois par mois. Veuillez ",
-        "communiquer avec nous",
-        " pour obtenir plus de renseignements"
-      ],
-      "step1": [
-        "Les fichiers de données peuvent être envoyés individuellement ou compressés en format .zip, .tar ou tar.gz. Consultez ",
-        "Formats de fichiers",
-        " pour obtenir de plus amples renseignements"
-      ],
-      "step2": [
-        "Vous connecter au serveur FTP du WOUDC ",
-        "en utilisant un client FTP"
-      ],
-      "step3": [
-        "Vous connecter à l’aide du nom d’utilisateur et du mot de passe qui vous a été attribué"
-      ],
-      "step4": [
-        "Chacun des contributeurs transfère ses fichiers respectifs dans leur dossier individuel sur le serveur FTP (une fois transférés au WOUDC, les fichiers ne peuvent être mis à jour pour soumettre des fichiers mis à jour, il faut les transférer de nouveau en utilisant un nom de fichier différent)"
-      ],
-      "step5": [
-        "Veuillez vous déconnecter pour mettre fin à la session FTP"
-      ],
+      "blurb1": "Le WOUDC traite les données de façon quotidienne afin que les soumissions de données soient complétées pratiquement en temps réel. Les contributeurs inscrits peuvent soumettre des données1 au WOUDC via le serveur FTP.",
+      "blurb2": {
+        "contact": "communiquer avec nous",
+        "template": "Il est recommandé de soumettre les données au moins une fois par mois. Veuillez {contact} pour obtenir plus de renseignements"
+      },
+      "step1": {
+        "formats": "Formats de fichiers",
+        "template": "Les fichiers de données peuvent être envoyés individuellement ou compressés en format .zip, .tar ou tar.gz. Consultez {formats} pour obtenir de plus amples renseignements"
+      },
+      "step2": {
+        "ftp": "en utilisant un client FTP",
+        "template": "Vous connecter au serveur FTP du WOUDC {ftp}"
+      },
+      "step3": "Vous connecter à l’aide du nom d’utilisateur et du mot de passe qui vous a été attribué",
+      "step4": "Chacun des contributeurs transfère ses fichiers respectifs dans leur dossier individuel sur le serveur FTP (une fois transférés au WOUDC, les fichiers ne peuvent être mis à jour pour soumettre des fichiers mis à jour, il faut les transférer de nouveau en utilisant un nom de fichier différent)",
+      "step5": "Veuillez vous déconnecter pour mettre fin à la session FTP",
       "note1": "une fois les fichiers transférés au WOUDC, il ne sera plus possible de les mettre à jour. Pour soumettre des fichiers mis à jour, les transférer de nouveau en utilisant un nom de fichier différent.",
       "note2": "les détails de chacune des étapes peuvent varier selon le type d’ordinateur et le serveur FTP.",
       "subtitle": "Étapes de soumission des données",
@@ -938,13 +920,13 @@
     }
   },
   "data": {
-    "links": [
-      "Rechercher des données / Télécharger",
-      "Produits de données",
-      "Information sur les jeux de données",
-      "Liste des stations",
-      "Liste des instruments"
-    ],
+    "links": {
+      "datasetinfo": "Information sur les jeux de données",
+      "explore": "Rechercher des données / Télécharger",
+      "instruments": "Liste des instruments",
+      "products": "Produits de données",
+      "stations": "Liste des stations"
+    },
     "title": "Données",
     "explore": {
       "blurb": [
@@ -971,31 +953,25 @@
     "info": {
       "blurb": "L'archive de données WOUDC peut fournir des informations de haut niveau sur chaque ensemble de données. Sélectionnez un ensemble de données d'intérêt pour voir ses métadonnées de découverte de l'ISO et une carte contextuelle des stations.",
       "sections": {
-        "total-ozone": {
-          "links": [
-            "Ozone total - observations quotidiennes",
-            "Ozone total - Observations horaires"
-          ],
+        "totalozone": {
+          "daily": "Ozone total - observations quotidiennes",
+          "hourly": "Ozone total - Observations horaires",
           "title": "Colonne d’ozone total"
         },
         "vertical-ozone": {
-          "links": [
-            "Lidar",
-            "Sonde pour l’ozone",
-            "UmkehrN14 (Niveau 1.0)",
-            "UmkehrN14 (Niveau 2.0)",
-            "RocketSonde"
-          ],
-          "title": "Courbe de répartition verticale de l’ozone"
+          "lidar": "Lidar",
+          "ozonesonde": "Sonde pour l’ozone",
+          "rocketsonde": "RocketSonde",
+          "title": "Courbe de répartition verticale de l’ozone",
+          "umkehr1": "UmkehrN14 (Niveau 1.0)",
+          "umkehr2": "UmkehrN14 (Niveau 2.0)"
         },
         "uv-irradiance": {
-          "links": [
-            "Large bande",
-            "Multibande",
-            "Spectrale",
-            "Indice UV"
-          ],
-          "title": "Rayonnement UV"
+          "broadband": "Large bande",
+          "multiband": "Multibande",
+          "spectral": "Spectrale",
+          "title": "Rayonnement UV",
+          "uv-index": "Indice UV"
         }
       },
       "subtitle": "Jeu de données",
@@ -1027,46 +1003,46 @@
       "blurb": "Des données de sortie spéciales sont préparées par le WOUDC afin d’aider les chercheurs et leur fournir des renseignements à valeur ajoutée ; certaines données comprennent des graphiques de série chronologique détaillant l’épaisseur de la colonne d’ozone total ainsi que des cartes indiquant la quantité d’ozone en temps quasi réel.",
       "maps": {
         "blurb": "Des cartes de l’ozone total en temps quasi réel, mises à jour quotidiennement à environ 14:00 (UTC).",
-        "links": [
-          "Cartes globales de l’ozone total les plus récentes",
-          "Cartes de l’ozone de l’hémisphère nord",
-          "Cartes de l’ozone de l’hémisphère sud",
-          "Archive des cartes d’ozone",
-          "Sources des données individuelles des cartes de l’ozone récentes et cartes de prévision de l’ozone"
-        ],
+        "links": {
+          "archive": "Archive des cartes d’ozone",
+          "global": "Cartes globales de l’ozone total les plus récentes",
+          "individual": "Sources des données individuelles des cartes de l’ozone récentes et cartes de prévision de l’ozone",
+          "north": "Cartes de l’ozone de l’hémisphère nord",
+          "south": "Cartes de l’ozone de l’hémisphère sud"
+        },
         "title": "Cartes de l’ozone"
       },
       "related": {
         "blurb": "_",
-        "links": [
-          "Données sommaires de l’ozone total : Moyennes quotidiennes et mensuelles",
-          "Comparaison des résultats d’ozone total obtenus au sol et par satellite",
-          "Données obtenues par la technique Umkehr par algorithme",
-          "Résumés et schémas des UV spectraux mensuels",
-          "Moyenne de l’ozone par zone obtenue par les instruments au sol",
-          "Ensemble de données cartographié par des Trajectoires provenant des sondages d'Ozone dans la Stratosphère et la Troposphère (TOST)"
-        ],
+        "links": {
+          "ozone-zonal": "Moyenne de l’ozone par zone obtenue par les instruments au sol",
+          "spectral": "Résumés et schémas des UV spectraux mensuels",
+          "tost": "Ensemble de données cartographié par des Trajectoires provenant des sondages d'Ozone dans la Stratosphère et la Troposphère (TOST)",
+          "totalozone-daily-monthly": "Données sommaires de l’ozone total : Moyennes quotidiennes et mensuelles",
+          "totalozone-satellite-ground": "Comparaison des résultats d’ozone total obtenus au sol et par satellite",
+          "umkehr": "Données obtenues par la technique Umkehr par algorithme"
+        },
         "title": "Produits relatifs à l'ozone"
       },
       "summaries": {
         "blurb": "_",
-        "links": [
-          "Les bulletins sur l'ozone de l'Antarctique et de l'Arctique - OMM",
-          "VAG recherche et rapports de surveillance - OMM",
-          "Recherche sur l'ozone mondial de surveillance et les rapports de projet - de l'OMM",
-          "Du trou d'ozone Watch - NASA",
-          "Mesures de satellite en orbite polaire - FMI",
-          "Emission troposphérique service surveillance d'Internet"
-        ],
+        "links": {
+          "gaw-reports": "VAG recherche et rapports de surveillance - OMM",
+          "ozone-reports": "Recherche sur l'ozone mondial de surveillance et les rapports de projet - de l'OMM",
+          "ozone-hole": "Du trou d'ozone Watch - NASA",
+          "polar-bulletins": "Les bulletins sur l'ozone de l'Antarctique et de l'Arctique - OMM",
+          "sampo": "Mesures de satellite en orbite polaire - FMI",
+          "temis": "Emission troposphérique service surveillance d'Internet"
+        },
         "title": "Sommaires et rapports des données"
       },
       "time-series": {
         "blurb": "Une variété de schémas sont disponibles afin de vérifier la disponibilité des données, par exemple.",
-        "links": [
-          "Schémas de sondes pour l’ozone",
-          "Schémas d’ozone total",
-          "Schémas d’indice UV"
-        ],
+        "links": {
+          "ozonesonde": "Schémas de sondes pour l’ozone",
+          "totalozone": "Schémas d’ozone total",
+          "uv-index": "Schémas d’indice UV"
+        },
         "title": "Graphiques de séries chronologiques"
       },
       "title": "Produits de données"
@@ -1118,20 +1094,20 @@
     "blurb": "Nouvelles pour le Centre de données, mises à jour et des notifications"
   },
   "resources": {
-    "links": [
-      "Procédures d'utilisation normalisées",
-      "Groupes de travail",
-      "Liens de données connexes",
-      "Logiciel"
-    ],
+    "links": {
+      "links": "Liens de données connexes",
+      "software": "Logiciel",
+      "sop": "Procédures d'utilisation normalisées",
+      "workinggroups": "Groupes de travail"
+    },
     "title": "Ressources",
     "procedures": {
       "blurb": "Liens vers les Procédures d'utilisation normalisées (PUN) sur l’ozone et les rayons UV Données sur le rayonnement.",
-      "headers": [
-        "Catégorie",
-        "PUN",
-        "Source"
-      ],
+      "headers": {
+        "category": "Catégorie",
+        "link": "PUN",
+        "source": "Source"
+      },
       "rows": [
         {
           "category": "PUN de Brewer",
@@ -1167,38 +1143,36 @@
       "title": "Procédures d'utilisation normalisées"
     },
     "related-links": {
-      "other-links": [
-        "Centre pour la validation de données du satellite Aura (AVDC) - NASA",
-        "Climat package de recherche de données (CRDP) - ESA",
-        "Laboratoire de recherche sur le système terrestre / division mondiale de surveillance (ESRL / GMD) - NOAA",
-        "Réseau européen pour le Brewer (de EUBREWNET)",
-        "Base de données UV européenne (EUVDB)",
-        "Chimie de l'ozone mondial et connexes enregistrements de données de traces de gaz pour la stratosphère (GOZCARDS) - NASA",
-        "Base de données MOZAIC / IAGOS ",
-        "Réseau de détection des changements de composition de l'atmosphère (NDACC) - NOAA",
-        "Réseau de surveillance NSF Polar Programs UV",
-        "Archives Polar / UVI données - NASA",
-        "Sondes d'ozone additionnelles de l'hémisphère sud (SHADOZ) - NASA"
-      ],
+      "links": {
+        "avdc": "Centre pour la validation de données du satellite Aura (AVDC) - NASA",
+        "crdp": "Climat package de recherche de données (CRDP) - ESA",
+        "esrl": "Laboratoire de recherche sur le système terrestre / division mondiale de surveillance (ESRL / GMD) - NOAA",
+        "eubrewnet": "Réseau européen pour le Brewer (de EUBREWNET)",
+        "euvdb": "Base de données UV européenne (EUVDB)",
+        "gawsis": "Système d'information sur les stations de la VAG (GAWSIS)",
+        "gozcards": "Chimie de l'ozone mondial et connexes enregistrements de données de traces de gaz pour la stratosphère (GOZCARDS) - NASA",
+        "mozaic": "Base de données MOZAIC / IAGOS ",
+        "ndacc": "Réseau de détection des changements de composition de l'atmosphère (NDACC) - NOAA",
+        "oscar": "L'outil OSCAR",
+        "polar": "Réseau de surveillance NSF Polar Programs UV",
+        "projects": "Projets et campagnes",
+        "shadoz": "Sondes d'ozone additionnelles de l'hémisphère sud (SHADOZ) - NASA",
+        "uvi": "Archives Polar / UVI données - NASA",
+        "wdc-aerosol": "Centre mondial de données relatives aux aérosols",
+        "wdc-ghg": "Centre mondial de données relatives aux gaz à effet de serre",
+        "wdc-precip": "Centre mondial de données relatives à la composition chimique des précipitations",
+        "wdc-sensing": "Centre mondial de données relatives à la télédétection de l’atmosphère",
+        "wrdc": "Centre mondial de données rde radiation"
+      },
       "other-title": "Autres données connexes",
-      "title": "Liens de données connexes",
-      "wmo-links": [
-        "Système d'information sur les stations de la VAG (GAWSIS)",
-        "L'outil OSCAR",
-        "Projets et campagnes",
-        "Centre mondial de données relatives aux aérosols",
-        "Centre mondial de données relatives aux gaz à effet de serre",
-        "Centre mondial de données relatives à la composition chimique des précipitations",
-        "Centre mondial de données relatives à la télédétection de l’atmosphère",
-        "Centre mondial de données rde radiation"
-      ]
+      "title": "Liens de données connexes"
     },
     "working-groups": {
-      "links": [
-        "Groupe d'utilasateurs pour le Brewer",
-        "Comité ad hoc pour le Dobson",
-        "Sous-comité pour la méthode d’Umkehr"
-      ],
+      "links": {
+        "brewer": "Groupe d'utilasateurs pour le Brewer",
+        "dobson": "Comité ad hoc pour le Dobson",
+        "umkehr": "Sous-comité pour la méthode d’Umkehr"
+      },
       "title": "Groupes de travail"
     }
   }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -37,7 +37,9 @@ export default {
   /*
    ** Global CSS
    */
-  css: [],
+  css: [
+    '~/css/globals.css'
+  ],
   /*
    ** Plugins to load before mounting the App
    */

--- a/pages/about/dataaccess.vue
+++ b/pages/about/dataaccess.vue
@@ -1,55 +1,65 @@
 <template>
   <div>
     <h1>{{ $t('about.access.title') }}</h1>
-    <v-card id="contents-table">
-      <v-card-title>{{ $t('about.access.contents.title') }}</v-card-title>
-      <v-list id="contents-body">
-        <div v-for="(section, i) in contents" :key="i">
-          <v-divider v-if="i !== 0" />
-          <v-list-item>
-            <nuxt-link :to="'#' + section.selector" v-text="section.text" />
-          </v-list-item>
-          <v-list-item v-if="section.children !== undefined">
-            <ul>
-              <li v-for="(child, j) in section.children" :key="j">
-                <nuxt-link :to="'#' + child.selector" v-text="child.text" />
-              </li>
-            </ul>
-          </v-list-item>
-        </div>
-      </v-list>
-    </v-card>
-    <i18n class="newlines" path="about.access.blurb.template" tag="p">
-      <template v-slot:contact>
-        <nuxt-link :to="localePath('contact')" v-text="$t('about.access.blurb.contact')" />
-      </template>
-    </i18n>
-    <v-card class="woudc-note" tile max-width="68%" min-width="0px">
-      <v-card-title>{{ $t('about.access.note1.title') }}</v-card-title>
-      <v-card-text>
-        <i18n path="about.access.note1.body.template" tag="p">
-          <template v-slot:policy>
-            <nuxt-link
-              :to="localePath('about-datapolicy')"
-              v-text="$t('about.access.note1.body.policy')"
-            />
+    <v-row>
+      <v-col cols="8">
+        <i18n class="newlines" path="about.access.blurb.template" tag="p">
+          <template v-slot:contact>
+            <nuxt-link :to="localePath('contact')" v-text="$t('about.access.blurb.contact')" />
           </template>
         </i18n>
-      </v-card-text>
-    </v-card>
-    <v-card class="woudc-note" tile max-width="68%" min-width="0px">
-      <v-card-title>{{ $t('about.access.note2.title') }}</v-card-title>
-      <v-card-text>
-        <i18n path="about.access.note2.body.template" tag="p">
-          <template v-slot:stations>
-            <nuxt-link
-              :to="localePath('data-stations')"
-              v-text="$t('about.access.note2.body.stations')"
-            />
-          </template>
-        </i18n>
-      </v-card-text>
-    </v-card>
+        <v-card class="mt-1 mb-4" color="info">
+          <v-card-title class="pt-3 pb-0">
+            {{ $t('about.access.note1.title') }}
+          </v-card-title>
+          <v-card-text>
+            <i18n class="mb-0" path="about.access.note1.body.template" tag="p">
+              <template v-slot:policy>
+                <nuxt-link
+                  :to="localePath('about-datapolicy')"
+                  v-text="$t('about.access.note1.body.policy')"
+                />
+              </template>
+            </i18n>
+          </v-card-text>
+        </v-card>
+        <v-card class="mt-1 mb-4" color="info">
+          <v-card-title class="pt-3 pb-0">
+            {{ $t('about.access.note2.title') }}
+          </v-card-title>
+          <v-card-text>
+            <i18n class="mb-0" path="about.access.note2.body.template" tag="p">
+              <template v-slot:stations>
+                <nuxt-link
+                  :to="localePath('data-stations')"
+                  v-text="$t('about.access.note2.body.stations')"
+                />
+              </template>
+            </i18n>
+          </v-card-text>
+        </v-card>
+      </v-col>
+      <v-col cols="4">
+        <v-card id="contents-table">
+          <v-card-title>{{ $t('about.access.contents.title') }}</v-card-title>
+          <v-list id="contents-body">
+            <div v-for="(section, i) in contents" :key="i">
+              <v-divider v-if="i !== 0" />
+              <v-list-item>
+                <nuxt-link :to="'#' + section.selector" v-text="section.text" />
+              </v-list-item>
+              <v-list-item v-if="section.children !== undefined">
+                <ul>
+                  <li v-for="(child, j) in section.children" :key="j">
+                    <nuxt-link :to="'#' + child.selector" v-text="child.text" />
+                  </li>
+                </ul>
+              </v-list-item>
+            </div>
+          </v-list>
+        </v-card>
+      </v-col>
+    </v-row>
     <div id="data-search-section">
       <h2>{{ $t('about.access.search.title') }}</h2>
       <i18n class="newlines" path="about.access.search.blurb.template" tag="p">
@@ -60,7 +70,7 @@
           <a :href="searchHelpURL" target="_blank">{{ $t('about.access.search.blurb.how-to') }}</a>
         </template>
       </i18n>
-      <v-card class="woudc-note" tile max-width="68%" min-width="0px">
+      <v-card class="mt-1 mb-4" color="info">
         <v-card-text>
           {{ $t('about.access.search.note') }}
         </v-card-text>
@@ -96,23 +106,27 @@
           <a :href="wisURL" target="_blank">{{ $t('about.access.web.blurb.wis') }}</a>
         </template>
       </i18n>
-      <v-card class="woudc-note" tile min-width="0px">
-        <v-card-title>{{ $t('about.access.web.table.title') }}</v-card-title>
+      <v-card class="mt-1 mb-4" color="info">
+        <v-card-title class="pt-3 pb-0">
+          {{ $t('about.access.web.table.title') }}
+        </v-card-title>
         <v-card-text>
-          <p>That font size is too big. Also the colour is wrong.</p>
+          <span>That font size is too big. Also the colour is wrong.</span>
         </v-card-text>
       </v-card>
       <div id="csw-subsection">
         <h2>{{ '1. ' + $t('about.access.csw.title') }}</h2>
-        <i18n path="about.access.csw.blurb.template" tag="p">
+        <i18n class="mb-0" path="about.access.csw.blurb.template" tag="p">
           <template v-slot:ogc>
             <a :href="ogcStandardsURL" target="_blank">{{ $t('about.access.csw.blurb.ogc') }}</a>
           </template>
         </i18n>
-        <v-card class="woudc-note" tile min-width="0px">
-          <v-card-title>{{ $t('about.access.csw.note.title') }}</v-card-title>
+        <v-card class="mt-1 mb-4" color="info">
+          <v-card-title class="pt-3 pb-0">
+            {{ $t('about.access.csw.note.title') }}
+          </v-card-title>
           <v-card-text>
-            <i18n path="about.access.csw.note.template" tag="p">
+            <i18n class="mb-0" path="about.access.csw.note.template" tag="p">
               <template v-slot:link>
                 <a :href="cswURL" target="_blank">{{ cswURL }}</a>
               </template>
@@ -127,10 +141,12 @@
             <a href="" target="_blank">{{ $t('about.access.wms.blurb.wms') }}</a>
           </template>
         </i18n>
-        <v-card class="woudc-note" tile min-width="0px">
-          <v-card-title>{{ $t('about.access.wms.note.title') }}</v-card-title>
+        <v-card class="mt-1 mb-4" color="info">
+          <v-card-title class="pt-3 pb-0">
+            {{ $t('about.access.wms.note.title') }}
+          </v-card-title>
           <v-card-text>
-            <i18n path="about.access.wms.note.template" tag="p">
+            <i18n class="mb-0" path="about.access.wms.note.template" tag="p">
               <template v-slot:link>
                 <a :href="wmsURL" target="_blank">{{ wmsURL }}</a>
               </template>
@@ -145,10 +161,12 @@
             <a href="" target="_blank">{{ $t('about.access.wfs.blurb.wfs') }}</a>
           </template>
         </i18n>
-        <v-card class="woudc-note" tile min-width="0px">
-          <v-card-title>{{ $t('about.access.wfs.note.title') }}</v-card-title>
+        <v-card class="mt-1 mb-4" color="info">
+          <v-card-title class="pt-3 pb-0">
+            {{ $t('about.access.wfs.note.title') }}
+          </v-card-title>
           <v-card-text>
-            <i18n path="about.access.wfs.note.template" tag="p">
+            <i18n class="mb-0" path="about.access.wfs.note.template" tag="p">
               <template v-slot:link>
                 <a :href="wfsURL" target="_blank">{{ wfsURL }}</a>
               </template>
@@ -163,10 +181,12 @@
             <a href="" target="_blank">{{ $t('about.access.wps.blurb.wps') }}</a>
           </template>
         </i18n>
-        <v-card class="woudc-note" tile min-width="0px">
-          <v-card-title>{{ $t('about.access.wps.note.title') }}</v-card-title>
+        <v-card class="mt-1 mb-4" color="info">
+          <v-card-title class="pt-3 pb-0">
+            {{ $t('about.access.wps.note.title') }}
+          </v-card-title>
           <v-card-text>
-            <i18n path="about.access.wps.note.template" tag="p">
+            <i18n class="mb-0" path="about.access.wps.note.template" tag="p">
               <template v-slot:link>
                 <a :href="wpsURL" target="_blank">{{ wpsURL }}</a>
               </template>
@@ -178,10 +198,12 @@
     <div id="definitions-service-section">
       <h2>{{ $t('about.access.definitions.title') }}</h2>
       <p>{{ $t('about.access.definitions.blurb') }}</p>
-      <v-card class="woudc-note" tile min-width="0px">
-        <v-card-title>{{ $t('about.access.definitions.note.title') }}</v-card-title>
+      <v-card class="mt-1 mb-4" color="info">
+        <v-card-title class="pt-3 pb-0">
+          {{ $t('about.access.definitions.note.title') }}
+        </v-card-title>
         <v-card-text>
-          <i18n path="about.access.definitions.note.template" tag="p">
+          <i18n class="mb-0" path="about.access.definitions.note.template" tag="p">
             <template v-slot:link>
               <a :href="definitionsURL" target="_blank">{{ definitionsURL }}</a>
             </template>
@@ -192,10 +214,12 @@
     <div id="iso-catalogue-section">
       <h2>{{ $t('about.access.iso.title') }}</h2>
       <p>{{ $t('about.access.iso.blurb1') }}</p>
-      <v-card class="woudc-note" tile min-width="0px">
-        <v-card-title>{{ $t('about.access.iso.note.title') }}</v-card-title>
+      <v-card class="mt-1 mb-4" color="info">
+        <v-card-title class="pt-3 pb-0">
+          {{ $t('about.access.iso.note.title') }}
+        </v-card-title>
         <v-card-text>
-          <i18n path="about.access.iso.note.template" tag="p">
+          <i18n class="mb-0" path="about.access.iso.note.template" tag="p">
             <template v-slot:link>
               <a :href="isoURL" target="_blank">{{ isoURL }}</a>
             </template>
@@ -302,11 +326,6 @@ export default {
 }
 
 #contents-table {
-  float: right;
-  max-width: 30%;
-
-  margin-left: 36px;
-
   color: white;
   background-color: royalblue;
 }

--- a/pages/about/datapolicy.vue
+++ b/pages/about/datapolicy.vue
@@ -17,9 +17,13 @@
     </i18n>
     <h2>{{ $t('about.policy.gaw.title') }}</h2>
     <p>{{ $t('about.policy.gaw.blurb') }}</p>
-    <v-card class="woudc-note" tile min-width="0px">
-      <v-card-title>{{ $t('about.policy.gaw.note.title') }}</v-card-title>
-      <v-card-text>{{ $t('about.policy.gaw.note.body') }}</v-card-text>
+    <v-card class="mt-1 mb-4" color="info">
+      <v-card-title class="pt-3 pb-0">
+        {{ $t('about.policy.gaw.note.title') }}
+      </v-card-title>
+      <v-card-text>
+        {{ $t('about.policy.gaw.note.body') }}
+      </v-card-text>
     </v-card>
     <h2>{{ $t('about.policy.doi.title') }}</h2>
     <i18n path="about.policy.doi.blurb.template" tag="p">

--- a/pages/about/formats.vue
+++ b/pages/about/formats.vue
@@ -9,8 +9,8 @@
         <nuxt-link :to="localePath('about-dataaccess')" v-text="$t('about.formats.blurb.access')" />
       </template>
     </i18n>
-    <v-card class="woudc-note" tile min-width="0px">
-      <v-card-text v-text="$t('about.formats.note')" />
+    <v-card class="mt-1 mb-4" color="info">
+      <v-card-text>{{ $t('about.formats.note') }}</v-card-text>
     </v-card>
     <h2> {{ $t('about.formats.contributor-guide.title') }}</h2>
     <ul>

--- a/pages/contributors/registration.vue
+++ b/pages/contributors/registration.vue
@@ -1,63 +1,69 @@
 <template>
   <v-layout justify-center column align-content-center>
     <h1>{{ $t('contributors.registration.title') }}</h1>
-    <woudc-blurb :items="blurb1" />
+    <i18n
+      class="newlines"
+      path="contributors.registration.blurb1.template"
+      tag="p"
+    >
+      <template v-slot:submission>
+        <nuxt-link
+          :to="localePath('contributors-submission')"
+          v-text="$t('contributors.registration.blurb1.submission')"
+        />
+      </template>
+    </i18n>
     <ol>
-      <li v-for="(blurb, i) in steps" :key="i">
-        <woudc-blurb :items="blurb" />
+      <li>
+        <i18n path="contributors.registration.step1.template" tag="span">
+          <template v-slot:policy>
+            <nuxt-link
+              :to="localePath('about-datapolicy')"
+              v-text="$t('contributors.registration.step1.policy')"
+            />
+          </template>
+        </i18n>
+      </li>
+      <li>
+        <i18n path="contributors.registration.step2.template" tag="span">
+          <template v-slot:wmo>
+            <a :href="gawHomeURL" target="_blank" v-text="$t('contributors.registration.step2.wmo')"></a>
+          </template>
+          <template v-slot:more>
+            <a :href="wmoGAWUrl" target="_blank" v-text="$t('contributors.registration.step2.more')"></a>
+          </template>
+        </i18n>
+      </li>
+      <li>
+        <i18n path="contributors.registration.step3.template" tag="span">
+          <template v-slot:contact>
+            <nuxt-link :to="localePath('contact')" v-text="$t('contributors.registration.step3.contact')" />
+          </template>
+          <template v-slot:register>
+            <strong>{{ $t('contributors.registration.step3.register') }}</strong>
+          </template>
+        </i18n>
+      </li>
+      <li>
+        {{ $t('contributors.registration.step4') }}
       </li>
     </ol>
-    <p>{{ blurb2 }}</p>
+    <p>{{ $t('contributors.registration.blurb2') }}</p>
   </v-layout>
 </template>
 
 <script>
-import WoudcBlurb from '~/components/WoudcBlurb'
-
 export default {
-  components: {
-    'woudc-blurb': WoudcBlurb
-  },
   data() {
     return {
-      blurb1: [
-        { text: this.$t('contributors.registration.blurb1[0]') },
-        { newlines: 2 },
-        { text: this.$t('contributors.registration.blurb1[1]') },
-        { link: { to: 'contributors-submission', text: this.$t('contributors.registration.blurb1[2]') } },
-        { text: this.$t('contributors.registration.blurb1[3]') }
-      ],
-      blurb2: this.$t('contributors.registration.blurb2[0]'),
-      steps: [
-        [
-          { text: this.$t('contributors.registration.step1[0]') },
-          { link: { to: 'about-datapolicy', text: this.$t('contributors.registration.step1[1]') } },
-          { text: ';' }
-        ],
-        [
-          { text: this.$t('contributors.registration.step2[0]') },
-          { link: { to: 'https://gawsis.meteoswiss.ch/', type: 'external', text: this.$t('contributors.registration.step2[1]') } },
-          { text: ' (' },
-          { link: { to: 'https://www.wmo.int/pages/prog/arep/gaw/gaw_home_en.html', type: 'external', text: this.$t('contributors.registration.step2[2]') } },
-          ');'
-        ],
-        [
-          { text: this.$t('contributors.registration.step3[0]') },
-          { link: { to: 'contact', text: this.$t('contributors.registration.step3[1]') } },
-          { text: this.$t('contributors.registration.step3[2]') },
-          { bold: this.$t('contributors.registration.step3[3]') },
-          { text: this.$t('contributors.registration.step3[4]') },
-        ],
-        [
-          { text: this.$t('contributors.registration.step4[0]') }
-        ]
-      ]
+      gawHomeURL: 'https://gawsis.meteoswiss.ch/',
+      wmoGAWUrl: 'https://www.wmo.int/pages/prog/arep/gaw/gaw_home_en.html'
     }
   },
   nuxtI18n: {
     paths: {
-      en: '/registration',
-      fr: '/registration-in-fr'
+      en: '/contributors/registration',
+      fr: '/contributeurs/inscription'
     }
   }
 }

--- a/pages/contributors/submission.vue
+++ b/pages/contributors/submission.vue
@@ -1,64 +1,64 @@
 <template>
   <v-layout justify-center column align-content-center>
     <h1>{{ $t('contributors.submission.title') }}</h1>
-    <woudc-blurb :items="blurb1" />
-    <span class="note">
-      <p>
-        <b>{{ $t('note') }} (1)</b>
-        {{ $t('contributors.submission.note1') }}
-      </p>
-    </span>
+    <p>{{ $t('contributors.submission.blurb1') }}</p>
+    <v-card class="woudc-note mt-1 mb-4">
+      <v-card-text>
+        <b>{{ $t('note') }} (1)</b> {{ $t('contributors.submission.note1') }}
+      </v-card-text>
+    </v-card>
     <h2>{{ $t('contributors.submission.subtitle') }}</h2>
     <ol>
-      <li v-for="(blurb, i) in steps" :key="i">
-        <woudc-blurb :items="blurb" />
+      <li>
+        <i18n path="contributors.submission.step1.template" tag="span">
+          <template v-slot:formats>
+            <nuxt-link
+              :to="localePath('about-formats')"
+              v-text="$t('contributors.submission.step1.formats')"
+            />
+          </template>
+        </i18n>
       </li>
+      <li>
+        <i18n path="contributors.submission.step2.template" tag="span">
+          <template v-slot:ftp>
+            <a :href="ftpPath" target="_blank">
+              {{ $t('contributors.submission.step2.ftp') }}
+            </a>
+          </template>
+        </i18n>
+      </li>
+      <li>{{ $t('contributors.submission.step3') }}</li>
+      <li>{{ $t('contributors.submission.step4') }}</li>
+      <li>{{ $t('contributors.submission.step5') }}</li>
     </ol>
-    <span class="note">
-      <p>
-        <b>{{ $t('note') }} (2)</b>
-        {{ $t('contributors.submission.note2') }}
-      </p>
-    </span>
-    <woudc-blurb :items="blurb2" />
+    <v-card class="woudc-note mt-1 mb-4">
+      <v-card-text>
+        <b>{{ $t('note') }} (2)</b> {{ $t('contributors.submission.note2') }}
+      </v-card-text>
+    </v-card>
+    <i18n path="contributors.submission.blurb2.template" tag="p">
+      <template v-slot:contact>
+        <nuxt-link
+          :to="localePath('contact')"
+          v-text="$t('contributors.submission.blurb2.contact')"
+        />
+      </template>
+    </i18n>
   </v-layout>
 </template>
 
 <script>
-import WoudcBlurb from '~/components/WoudcBlurb'
-
 export default {
-  components: {
-    'woudc-blurb': WoudcBlurb
-  },
   data() {
     return {
-      blurb1: [ { text: this.$t('contributors.submission.blurb1[0]') } ],
-      blurb2: [
-        { text: this.$t('contributors.submission.blurb2[0]') },
-        { link: { to: 'contact', text: this.$t('contributors.submission.blurb2[1]') } },
-        { text: this.$t('contributors.submission.blurb2[2]') }
-      ],
-      steps: [
-        [
-          { text: this.$t('contributors.submission.step1[0]') },
-          { link: { to: 'about-formats', text: this.$t('contributors.submission.step1[1]') } },
-          { text: this.$t('contributors.submission.step1[2]') }
-        ],
-        [
-          { text: this.$t('contributors.submission.step2[0]') },
-          { link: { to: 'ftp://ftp.woudc.org/', type: 'external', text: this.$t('contributors.submission.step2[1]') } }
-        ],
-        this.$t('contributors.submission.step3[0]'),
-        this.$t('contributors.submission.step4[0]'),
-        this.$t('contributors.submission.step5[0]')
-      ],
+      ftpPath: 'ftp://ftp.woudc.org/'
     }
   },
   nuxtI18n: {
     paths: {
-      en: '/submission',
-      fr: '/submission-in-fr'
+      en: '/contributors/submission',
+      fr: '/contributeurs/soumission'
     }
   }
 }

--- a/pages/contributors/validation.vue
+++ b/pages/contributors/validation.vue
@@ -4,3 +4,14 @@
     <p>{{ $t('contributors.validation.blurb') }}</p>
   </v-layout>
 </template>
+
+<script>
+export default {
+  nuxtI18n: {
+    paths: {
+      en: '/contributors/validation',
+      fr: '/contributeurs/validateur'
+    }
+  }
+}
+</script>

--- a/pages/data/datasetinfo/index.vue
+++ b/pages/data/datasetinfo/index.vue
@@ -2,14 +2,34 @@
   <v-layout justify-center column align-content-center>
     <h1>{{ $t('data.info.title') }}</h1>
     <p>{{ $t('data.info.blurb') }}</p>
-    <h3>{{ $t('data.info.subtitle') }}</h3>
+    <h2>{{ $t('data.info.subtitle') }}</h2>
     <ul>
-      <li v-for="(value, name) in links" :key="name">
-        {{ $t('data.info.sections.' + name + '.title') }}
+      <li id="totalozone-section">
+        <span>{{ $t('data.info.sections.totalozone.title') }}</span>
         <ul>
-          <li v-for="link in value" :key="link.to">
-            <nuxt-link :to="localePath(link.to)">
-              {{ link.text }}
+          <li v-for="(path, key) in totalozoneLinks" :key="key">
+            <nuxt-link :to="localePath(path)">
+              {{ $t('data.info.sections.totalozone.' + key) }}
+            </nuxt-link>
+          </li>
+        </ul>
+      </li>
+      <li id="ozone-section">
+        <span>{{ $t('data.info.sections.vertical-ozone.title') }}</span>
+        <ul>
+          <li v-for="(path, key) in ozoneLinks" :key="key">
+            <nuxt-link :to="localePath(path)">
+              {{ $t('data.info.sections.vertical-ozone.' + key) }}
+            </nuxt-link>
+          </li>
+        </ul>
+      </li>
+      <li id="uv-section">
+        <span>{{ $t('data.info.sections.uv-irradiance.title') }}</span>
+        <ul>
+          <li v-for="(path, key) in uvLinks" :key="key">
+            <nuxt-link :to="localePath(path)">
+              {{ $t('data.info.sections.uv-irradiance.' + key) }}
             </nuxt-link>
           </li>
         </ul>
@@ -22,81 +42,29 @@
 export default {
   data() {
     return {
-      links: {
-        'total-ozone': [
-          {
-            text: this.$t('data.info.sections.total-ozone.links[0]'),
-            to: 'data-datasetinfo-totalozone'
-          },
-          {
-            text: this.$t('data.info.sections.total-ozone.links[1]'),
-            to: 'data-datasetinfo-totalozoneobs'
-          }
-        ],
-        'vertical-ozone': [
-          {
-            text: this.$t('data.info.sections.vertical-ozone.links[0]'),
-            to: 'data-datasetinfo-lidar'
-          },
-          {
-            text: this.$t('data.info.sections.vertical-ozone.links[1]'),
-            to: 'data-datasetinfo-ozonesonde'
-          },
-          {
-            text: this.$t('data.info.sections.vertical-ozone.links[2]'),
-            to: 'data-datasetinfo-umkehrn14-1'
-          },
-          {
-            text: this.$t('data.info.sections.vertical-ozone.links[3]'),
-            to: 'data-datasetinfo-umkehrn14-2'
-          },
-          {
-            text: this.$t('data.info.sections.vertical-ozone.links[4]'),
-            to: 'data-datasetinfo-rocketsonde'
-          }
-        ],
-        'uv-index': [
-          {
-            text: this.$t('data.info.sections.uv-irradiance.links[0]'),
-            to: 'data-datasetinfo-broadband'
-          },
-          {
-            text: this.$t('data.info.sections.uv-irradiance.links[1]'),
-            to: 'data-datasetinfo-multiband'
-          },
-          {
-            text: this.$t('data.info.sections.uv-irradiance.links[2]'),
-            to: 'data-datasetinfo-spectral'
-          },
-          {
-            text: this.$t('data.info.sections.uv-irradiance.links[3]'),
-            to: 'data-datasetinfo-uvindex'
-          }
-        ]
+      ozoneLinks: {
+        lidar: 'data-datasetinfo-lidar',
+        ozonesonde: 'data-datasetinfo-ozonesonde',
+        rocketsonde: 'data-datasetinfo-rocketsonde',
+        umkehr1: 'data-datasetinfo-umkehrn14-1',
+        umkehr2: 'data-datasetinfo-umkehrn14-2'
+      },
+      totalozoneLinks: {
+        daily: 'data-datasetinfo-totalozone',
+        hourly: 'data-datasetinfo-totalozoneobs'
+      },
+      uvLinks: {
+        broadband: 'data-datasetinfo-broadband',
+        multiband: 'data-datasetinfo-multiband',
+        spectral: 'data-datasetinfo-spectral',
+        'uv-index': 'data-datasetinfo-uvindex'
       }
-    }
-  },
-  computed: {
-    totalOzoneSectionHead() {
-      return this.$t('data.info.sections.total-ozone.title')
-    },
-    verticalOzoneSectionHead() {
-      return this.$t('data.info.sections.vertical-ozone.title')
-    },
-    uvIrradianceSectionHead() {
-      return this.$t('data.info.sections.uv-irradiance.title')
-    }
-  },
-  methods: {
-    constructLink(dataset) {
-      const basepath = 'data-datasetinfo'
-      return this.localePath(basepath) + '/' + dataset
     }
   },
   nuxtI18n: {
     paths: {
-      en: '/datasetinfo',
-      fr: '/datasetinfo-in-fr'
+      en: '/data/info',
+      fr: '/donnees/information'
     }
   }
 }

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -1,10 +1,10 @@
 <template>
   <v-layout justify-center column align-content-center>
-    <h1>{{ $t('data.title') }}</h1>
+    <h2>{{ $t('data.title') }}</h2>
     <ul>
-      <li v-for="(link, i) in links" :key="i">
-        <nuxt-link :to="localePath(link.to)">
-          {{ link.text }}
+      <li v-for="path in localLinks" :key="path">
+        <nuxt-link :to="localePath('data-' + path)">
+          {{ $t('data.links.' + path) }}
         </nuxt-link>
       </li>
     </ul>
@@ -15,13 +15,15 @@
 export default {
   data() {
     return {
-      links: [
-        { to: 'data-explore', text: this.$t('data.links[0]') },
-        { to: 'data-products', text: this.$t('data.links[1]') },
-        { to: 'data-datasetinfo', text: this.$t('data.links[2]') },
-        { to: 'data-stations', text: this.$t('data.links[3]') },
-        { to: 'data-instruments', text: this.$t('data.links[4]') }
-      ]
+      localLinks: [
+        'explore', 'products', 'datasetinfo', 'stations', 'instruments'
+      ],
+    }
+  },
+  nuxtI18n: {
+    paths: {
+      en: '/data',
+      fr: '/donnees'
     }
   }
 }

--- a/pages/data/products/index.vue
+++ b/pages/data/products/index.vue
@@ -2,50 +2,48 @@
   <v-layout justify-center column align-content-center>
     <h1>{{ $t('data.products.title') }}</h1>
     <p>{{ $t('data.products.blurb') }}</p>
-    <h2>{{ $t('data.products.time-series.title') }}</h2>
-    <p v-if="$t('data.products.time-series.blurb').length > 0">
-      {{ $t('data.products.time-series.blurb') }}
-    </p>
-    <ul>
-      <li v-for="(link, i) in timeSeriesLinks" :key="i">
-        <nuxt-link :to="localePath(link.to)">
-          {{ link.text }}
-        </nuxt-link>
-      </li>
-    </ul>
-    <h2>{{ $t('data.products.related.title') }}</h2>
-    <p v-if="$t('data.products.related.blurb') !== EMPTY_CHAR">
-      {{ $t('data.products.related.blurb') }}
-    </p>
-    <ul>
-      <li v-for="(link, i) in relatedLinks" :key="i">
-        <a :href="link.to">
-          {{ link.text }}
-        </a>
-      </li>
-    </ul>
-    <h2>{{ $t('data.products.maps.title') }}</h2>
-    <p v-if="$t('data.products.maps.blurb') !== EMPTY_CHAR">
-      {{ $t('data.products.maps.blurb') }}
-    </p>
-    <ul>
-      <li v-for="(link, i) in mapsLinks" :key="i">
-        <a :href="link.to">
-          {{ link.text }}
-        </a>
-      </li>
-    </ul>
-    <h2>{{ $t('data.products.summaries.title') }}</h2>
-    <p v-if="$t('data.products.summaries.blurb') !== EMPTY_CHAR">
-      {{ $t('data.products.summaries.blurb') }}
-    </p>
-    <ul>
-      <li v-for="(link, i) in summariesLinks" :key="i">
-        <a :href="link.to">
-          {{ link.text }}
-        </a>
-      </li>
-    </ul>
+    <div id="time-series">
+      <h2>{{ $t('data.products.time-series.title') }}</h2>
+      <p>{{ $t('data.products.time-series.blurb') }}</p>
+      <ul>
+        <li v-for="(path, key) in timeSeriesLinks" :key="key">
+          <nuxt-link :to="localePath(path)">
+            {{ $t('data.products.time-series.links.' + key) }}
+          </nuxt-link>
+        </li>
+      </ul>
+    </div>
+    <div id="related-products">
+      <h2>{{ $t('data.products.related.title') }}</h2>
+      <ul>
+        <li v-for="(url, key) in relatedLinks" :key="key">
+          <a :href="url" target="_blank">
+            {{ $t('data.products.related.links.' + key) }}
+          </a>
+        </li>
+      </ul>
+    </div>
+    <div id="ozone-maps">
+      <h2>{{ $t('data.products.maps.title') }}</h2>
+      <p>{{ $t('data.products.maps.blurb') }}</p>
+      <ul>
+        <li v-for="(url, key) in mapsLinks" :key="key">
+          <a :href="url" target="_blank">
+            {{ $t('data.products.maps.links.' + key) }}
+          </a>
+        </li>
+      </ul>
+    </div>
+    <div id="summaries">
+      <h2>{{ $t('data.products.summaries.title') }}</h2>
+      <ul>
+        <li v-for="(url, key) in summariesLinks" :key="key">
+          <a :href="url" target="_blank">
+            {{ $t('data.products.summaries.links.' + key) }}
+          </a>
+        </li>
+      </ul>
+    </div>
   </v-layout>
 </template>
 
@@ -53,101 +51,40 @@
 export default {
   data() {
     return {
-      EMPTY_CHAR: '_',
-      mapsLinks: [
-        {
-          text: this.$t('data.products.maps.links[0]'),
-          to: 'http://exp-studies.tor.ec.gc.ca/e/ozone/Curr_allmap_g.htm'
-        },
-        {
-          text: this.$t('data.products.maps.links[1]'),
-          to: 'http://exp-studies.tor.ec.gc.ca/e/ozone/Curr_allmap.htm'
-        },
-        {
-          text: this.$t('data.products.maps.links[2]'),
-          to: 'http://exp-studies.tor.ec.gc.ca/e/ozone/Curr_allmap_s.htm'
-        },
-        {
-          text: this.$t('data.products.maps.links[3]'),
-          to: 'http://exp-studies.tor.ec.gc.ca/cgi-bin/selectMap'
-        },
-        {
-          text: this.$t('data.products.maps.links[4]'),
-          to: 'http://exp-studies.tor.ec.gc.ca/cgi-bin/dailyMaps'
-        }
-      ],
-      relatedLinks: [
-        {
-          text: this.$t('data.products.related.links[0]'),
-          to: 'https://woudc.org/archive/Summaries/TotalOzone'
-        },
-        {
-          text: this.$t('data.products.related.links[1]'),
-          to: 'https://woudc.org/archive/Projects-Campaigns/Ground-Sat_Plots/'
-        },
-        {
-          text: this.$t('data.products.related.links[2]'),
-          to: 'https://woudc.org/archive/Summaries/Umkehr'
-        },
-        {
-          text: this.$t('data.products.related.links[3]'),
-          to: 'https://woudc.org/archive/Summaries/Spectral_UV'
-        },
-        {
-          text: this.$t('data.products.related.links[4]'),
-          to: 'https://woudc.org/archive/Projects-Campaigns/ZonalMeans'
-        },
-        {
-          text: this.$t('data.products.related.links[5]'),
-          to: 'https://woudc.org/archive/products/ozone/vertical-ozone-profile/ozonesonde/1.0/tost'
-        }
-      ],
-      summariesLinks: [
-        {
-          text: this.$t('data.products.summaries.links[0]'),
-          to: 'https://www.wmo.int/pages/prog/arep/gaw/ozone/index.html'
-        },
-        {
-          text: this.$t('data.products.summaries.links[1]'),
-          to: 'https://www.wmo.int/pages/prog/arep/gaw/gaw-reports.html'
-        },
-        {
-          text: this.$t('data.products.summaries.links[2]'),
-          to: 'https://www.wmo.int/pages/prog/arep/gaw/ozone_reports.html'
-        },
-        {
-          text: this.$t('data.products.summaries.links[3]'),
-          to: 'https://ozonewatch.gsfc.nasa.gov/SH.html'
-        },
-        {
-          text: this.$t('data.products.summaries.links[4]'),
-          to: 'https://sampo.fmi.fi/'
-        },
-        {
-          text: this.$t('data.products.summaries.links[5]'),
-          to: 'http://www.temis.nl/index.php'
-        }
-      ],
-      timeSeriesLinks: [
-        {
-          text: this.$t('data.products.time-series.links[0]'),
-          to: '/data/products/ozonesonde'
-        },
-        {
-          text: this.$t('data.products.time-series.links[1]'),
-          to: '/data/products/totalozone'
-        },
-        {
-          text: this.$t('data.products.time-series.links[2]'),
-          to: '/data/products/uv-index'
-        }
-      ]
+      mapsLinks: {
+        global: 'http://exp-studies.tor.ec.gc.ca/e/ozone/Curr_allmap_g.htm',
+        north: 'http://exp-studies.tor.ec.gc.ca/e/ozone/Curr_allmap.htm',
+        south: 'http://exp-studies.tor.ec.gc.ca/e/ozone/Curr_allmap_s.htm',
+        archive: 'http://exp-studies.tor.ec.gc.ca/cgi-bin/selectMap',
+        individual: 'http://exp-studies.tor.ec.gc.ca/cgi-bin/dailyMaps'
+      },
+      relatedLinks: {
+        'totalozone-daily-monthly': 'https://woudc.org/archive/Summaries/TotalOzone',
+        'totalozone-satellite-ground': 'https://woudc.org/archive/Projects-Campaigns/Ground-Sat_Plots/',
+        umkehr: 'https://woudc.org/archive/Summaries/Umkehr',
+        spectral: 'https://woudc.org/archive/Summaries/Spectral_UV',
+        'ozone-zonal': 'https://woudc.org/archive/Projects-Campaigns/ZonalMeans',
+        tost: 'https://woudc.org/archive/products/ozone/vertical-ozone-profile/ozonesonde/1.0/tost'
+      },
+      summariesLinks: {
+        'polar-bulletins': 'https://www.wmo.int/pages/prog/arep/gaw/ozone/index.html',
+        'gaw-reports': 'https://www.wmo.int/pages/prog/arep/gaw/gaw-reports.html',
+        'ozone-reports': 'https://www.wmo.int/pages/prog/arep/gaw/ozone_reports.html',
+        'ozone-hole': 'https://ozonewatch.gsfc.nasa.gov/SH.html',
+        sampo: 'https://sampo.fmi.fi/',
+        temis: 'http://www.temis.nl/index.php'
+      },
+      timeSeriesLinks: {
+        ozonesonde: '/data/products/ozonesonde',
+        totalozone: '/data/products/totalozone',
+        'uv-index': '/data/products/uv-index'
+      }
     }
   },
   nuxtI18n: {
     paths: {
-      en: '/products',
-      fr: '/produits'
+      en: '/data/products',
+      fr: '/donnees/produits'
     }
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -19,7 +19,7 @@
           <div class="d-flex flex-no-wrap justify-space-between">
             <div>
               <v-card-title class="headline">
-                <a target="_blank" href="http://www.wmo.int" itemprop="name">
+                <a :href="wmoURL" target="_blank" itemprop="name">
                   {{ $t('wmo') }}
                 </a>
               </v-card-title>
@@ -28,7 +28,7 @@
               </v-card-subtitle>
             </div>
             <v-avatar class="ma-3" size="150" tile>
-              <a target="_blank" href="http://www.wmo.int" itemprop="url">
+              <a target="_blank" :href="wmoURL" itemprop="url">
                 <v-img
                   :src="require('~/assets/wmo_acronym_vertical_sm.jpg')"
                   :alt="$t('home.wmoLogo')"
@@ -50,11 +50,7 @@
           <div class="d-flex flex-no-wrap justify-space-between">
             <div>
               <v-card-title class="headline">
-                <a
-                  target="_blank"
-                  href="http://www.wmo.int/gaw"
-                  itemprop="name"
-                >
+                <a target="_blank" :href="gawURL" itemprop="name">
                   {{ $t('gaw') }}
                 </a>
               </v-card-title>
@@ -63,7 +59,7 @@
               </v-card-subtitle>
             </div>
             <v-avatar class="ma-3" size="150" tile>
-              <a target="_blank" href="http://www.wmo.int/gaw" itemprop="url">
+              <a :href="gawURL" target="_blank" itemprop="url">
                 <v-img
                   :src="require('~/assets/gaw_acronym_vertical_sm.jpg')"
                   :alt="$t('home.gawLogo')"
@@ -77,11 +73,14 @@
         </v-card>
       </v-container>
       <v-card-text itemprop="description">
-        A World Meteorological Organization (
-        <a href="https://www.wmo.int" target="_blank">{{ $t('wmo') }}</a>
-        ) data centre supporting the Global Atmosphere Watch (
-        <a href="https://www.wmo.int/gaw" target="_blank">{{ $t('gaw') }}</a>
-        ) program operated by Environment and Climate Change Canada.
+        <i18n path="home.blurb" tag="span">
+          <template v-slot:wmo>
+            <a :href="wmoURL" target="_blank">{{ $t('wmo') }}</a>
+          </template>
+          <template v-slot:gaw>
+            <a :href="gawURL" target="_blank">{{ $t('gaw') }}</a>
+          </template>
+        </i18n>
       </v-card-text>
       <v-card-actions>
         <v-btn
@@ -102,11 +101,8 @@ export default {
   name: 'Home',
   data() {
     return {
-      envVarTest: {
-        servicesHostname: process.env.SERVICES_HOSTNAME,
-        routerBase: process.env.ROUTER_BASE,
-        emailAddress: process.env.EMAIL_ADDRESS
-      }
+      gawURL: 'http://www.wmo.int/gaw',
+      wmoURL: 'http://www.wmo.int'
     }
   },
   head() {

--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -2,13 +2,15 @@
   <v-layout justify-center column align-content-center>
     <h2>{{ $t('resources.title') }}</h2>
     <ul>
-      <li v-for="(link, i) in links" :key="i">
-        <a v-if="link.type === 'external'" :href="link.to">
-          {{ link.text }}
-        </a>
-        <nuxt-link v-else :to="localePath(link.to)">
-          {{ link.text }}
+      <li v-for="path in localLinks" :key="path">
+        <nuxt-link :to="localePath('resources-' + path)">
+          {{ $t('resources.links.' + path) }}
         </nuxt-link>
+      </li>
+      <li>
+        <a :href="softwareURL" target="_blank">
+          {{ $t('resources.links.software') }}
+        </a>
       </li>
     </ul>
   </v-layout>
@@ -18,12 +20,8 @@
 export default {
   data() {
     return {
-      links: [
-        { to: 'resources-sop', text: this.$t('resources.links[0]') },
-        { to: 'resources-workinggroups', text: this.$t('resources.links[1]') },
-        { to: 'resources-links', text: this.$t('resources.links[2]') },
-        { to: 'https://github.com/woudc/woudc/wiki', type: 'external', text: this.$t('resources.links[3]') }
-      ]
+      localLinks: [ 'sop', 'workinggroups', 'links' ],
+      softwareURL: 'https://github.com/woudc/woudc/wiki'
     }
   },
   nuxtI18n: {

--- a/pages/resources/links.vue
+++ b/pages/resources/links.vue
@@ -3,17 +3,17 @@
     <h1>{{ $t('resources.related-links.title') }}</h1>
     <h2>{{ $t('wmo') }}</h2>
     <ul>
-      <li v-for="(link, i) in wmoLinks" :key="i">
-        <a :href="link.to">
-          {{ link.text }}
+      <li v-for="(value, key) in wmoURLs" :key="key">
+        <a :href="value" target="_blank">
+          {{ $t('resources.related-links.links.' + key) }}
         </a>
       </li>
     </ul>
     <h2>{{ $t('resources.related-links.other-title') }}</h2>
     <ul>
-      <li v-for="(link, i) in otherLinks" :key="i">
-        <a :href="link.to">
-          {{ link.text }}
+      <li v-for="(value, key) in relatedURLs" :key="key">
+        <a :href="value" target="_blank">
+          {{ $t('resources.related-links.links.' + key) }}
         </a>
       </li>
     </ul>
@@ -21,52 +21,38 @@
 </template>
 
 <script>
-const otherURLs = [
-  'https://avdc.gsfc.nasa.gov/',
-  'http://cci.esa.int/ozone/?q=node/160',
-  'https://www.esrl.noaa.gov/gmd/dv/data/',
-  'http://www.eubrewnet.org/cost1207/',
-  'https://www1.muk.uni-hannover.de/~seckmeyer/EDUCE/',
-  'https://gozcards.jpl.nasa.gov/',
-  'http://www.iagos-data.fr/',
-  'https://www.ndsc.ncep.noaa.gov/data/',
-  'http://uv.biospherical.com/',
-  'https://spacephysics.msfc.nasa.gov/projects/uvi/data_archives.shtml',
-  'https://croc.gsfc.nasa.gov/shadoz/'
-]
-
-const wmoURLs = [
-  'https://gawsis.meteoswiss.ch/',
-  'https://www.wmo-sat.info/oscar/',
-  'https://woudc.org/archive/Projects-Campaigns',
-  'https://www.gaw-wdca.org/',
-  'https://gaw.kishou.go.jp/',
-  'http://wdcpc.org/',
-  'https://wdc.dlr.de/',
-  'http://wrdc.mgo.rssi.ru/'
-]
-
 export default {
   data() {
     return {
-      wmoLinks: [...wmoURLs.keys()].map((index) => {
-        return {
-          text: this.$t('resources.related-links.wmo-links[' + index + ']'),
-          to: wmoURLs[index]
-        }
-      }),
-      otherLinks: [...otherURLs.keys()].map((index) => {
-        return {
-          text: this.$t('resources.related-links.other-links[' + index + ']'),
-          to: otherURLs[index]
-        }
-      })
+      wmoURLs: {
+        gawsis: 'https://gawsis.meteoswiss.ch/',
+        oscar: 'https://www.wmo-sat.info/oscar/',
+        projects: 'https://woudc.org/archive/Projects-Campaigns',
+        'wdc-aerosol': 'https://www.gaw-wdca.org/',
+        'wdc-ghg': 'https://gaw.kishou.go.jp/',
+        'wdc-precip': 'http://wdcpc.org/',
+        'wdc-sensing': 'https://wdc.dlr.de/',
+        wrdc: 'http://wrdc.mgo.rssi.ru/'
+      },
+      relatedURLs: {
+        avdc: 'https://avdc.gsfc.nasa.gov/',
+        crdp: 'http://cci.esa.int/ozone/?q=node/160',
+        esrl: 'https://www.esrl.noaa.gov/gmd/dv/data/',
+        eubrewnet: 'http://www.eubrewnet.org/cost1207/',
+        euvdb: 'https://www1.muk.uni-hannover.de/~seckmeyer/EDUCE/',
+        gozcards: 'https://gozcards.jpl.nasa.gov/',
+        mozaic: 'http://www.iagos-data.fr/',
+        ndacc: 'https://www.ndsc.ncep.noaa.gov/data/',
+        polar: 'http://uv.biospherical.com/',
+        uvi: 'https://spacephysics.msfc.nasa.gov/projects/uvi/data_archives.shtml',
+        shadoz: 'https://croc.gsfc.nasa.gov/shadoz/'
+      }
     }
   },
   nuxtI18n: {
     paths: {
-      en: '/links',
-      fr: '/links-in-fr'
+      en: '/resources/links',
+      fr: '/ressources/liens'
     }
   }
 }

--- a/pages/resources/sop.vue
+++ b/pages/resources/sop.vue
@@ -10,9 +10,7 @@
     >
       <template v-slot:item.link="link">
         <td>
-          <a :href="link.item.to">
-            {{ link.item.text }}
-          </a>
+          <a :href="link.item.to" target="_blank">{{ link.item.text }}</a>
         </td>
       </template>
     </v-data-table>
@@ -20,29 +18,31 @@
 </template>
 
 <script>
-const headerKeys = [ 'category', 'link', 'source' ]
-
-const linkURLs = [
-  'https://woudc.org/archive/Documentation/SOP_Documents',
-  'https://www.wmo.int/pages/prog/arep/gaw/documents/GAW183-Dobson-WEB.pdf',
-  'https://www.wmo.int/pages/prog/arep/gaw/documents/GAW_201.pdf',
-  'https://www.wmo.int/pages/prog/arep/gaw/documents/Final_GAW198_18_June.pdf',
-  'https://www.wmo.int/pages/prog/arep/gaw/documents/GAW191_TD_No_1538_web.pdf',
-  'https://www.wmo.int/pages/prog/arep/gaw/documents/GAW190_TD_No_1537_web.pdf'
-]
-
 export default {
-  data() {
-    return {
-      headers: [...headerKeys.keys()].map((index) => {
+  computed: {
+    headers() {
+      const headerKeys = [ 'category', 'link', 'source' ]
+
+      return headerKeys.map((column) => {
         return {
-          text: this.$t('resources.procedures.headers[' + index + ']'),
           align: 'left',
           sortable: false,
-          value: headerKeys[index]
+          value: column,
+          text: this.$t('resources.procedures.headers.' + column)
         }
-      }),
-      rows: [...linkURLs.keys()].map((index) => {
+      })
+    },
+    rows() {
+      const linkURLs = [
+        'https://woudc.org/archive/Documentation/SOP_Documents',
+        'https://www.wmo.int/pages/prog/arep/gaw/documents/GAW183-Dobson-WEB.pdf',
+        'https://www.wmo.int/pages/prog/arep/gaw/documents/GAW_201.pdf',
+        'https://www.wmo.int/pages/prog/arep/gaw/documents/Final_GAW198_18_June.pdf',
+        'https://www.wmo.int/pages/prog/arep/gaw/documents/GAW191_TD_No_1538_web.pdf',
+        'https://www.wmo.int/pages/prog/arep/gaw/documents/GAW190_TD_No_1537_web.pdf'
+      ]
+
+      return [...linkURLs.keys()].map((index) => {
         const definition = this.$t('resources.procedures.rows[' + index + ']')
         definition.to = linkURLs[index]
 
@@ -52,8 +52,8 @@ export default {
   },
   nuxtI18n: {
     paths: {
-      en: '/sop',
-      fr: '/sop-in-fr'
+      en: '/resources/sop',
+      fr: '/ressources/pun'
     }
   }
 }

--- a/pages/resources/workinggroups.vue
+++ b/pages/resources/workinggroups.vue
@@ -2,9 +2,9 @@
   <v-layout justify-center column align-content-center>
     <h1>{{ $t('resources.working-groups.title') }}</h1>
     <ul>
-      <li v-for="(link, i) in links" :key="i">
-        <a :href="link.to">
-          {{ link.text }}
+      <li v-for="(value, key) in urls" :key="key">
+        <a :href="value" target="_blank">
+          {{ $t('resources.working-groups.links.' + key) }}
         </a>
       </li>
     </ul>
@@ -12,27 +12,20 @@
 </template>
 
 <script>
-const urls = [
-  'https://woudc.org/archive/Documentation/www/bdms/meetings/',
-  'http://www.o3soft.eu/dobsonweb/committee.html',
-  'https://woudc.org/archive/Publications/Meeting_Reports/Umkehr_Sub-Committee/'
-]
-
 export default {
   data() {
     return {
-      links: [...urls.keys()].map((index) => {
-        return {
-          text: this.$t('resources.working-groups.links[' + index + ']'),
-          to: urls[index]
-        }
-      })
+      urls: {
+        brewer: 'https://woudc.org/archive/Documentation/www/bdms/meetings/',
+        dobson: 'http://www.o3soft.eu/dobsonweb/committee.html',
+        umkehr: 'https://woudc.org/archive/Publications/Meeting_Reports/Umkehr_Sub-Committee/'
+      }
     }
   },
   nuxtI18n: {
     paths: {
-      en: '/workinggroups',
-      fr: '/workinggroups-in-fr'
+      en: '/resources/working-groups',
+      fr: '/ressources/groupes-travail'
     }
   }
 }


### PR DESCRIPTION
Removes all occurrences of the woudc-blurb, woudc-note, and woudc-link components and replaces them with straight-up Vue components in the remaining static pages in multiple sections.

Mainly affects the Resources section, as well as a few index pages and miscellaneous static pages in the Data and Contributors section.

Intended as part of a cleanup of the translation system, so that blurbs are built using readable component substitution rather than being set up behind-the-scenes by all these custom components. So translations in the JSON files and their uses in the Vue components in static pages have been cleaned up.