### PR TITLE
Unpack Components - Non-static Pages

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -7,6 +7,20 @@
   "wmo": "WMO",
   "wmoFull": "World Meteorological Organization",
   "woudcFull": "World Ozone and Ultraviolet Radiation Data Centre",
+  "map-instructions": {
+    "label": "How to Use: Interactive Map",
+    "panning": "Panning:",
+    "tab": "Tab",
+    "template": "{panning} To pan the map, click and drag over the interactive map. Alternatively, {tab} focus to the interactive map box and then press the arrow keys.\n\n{zooming} To zoom in and out of the map, mouse scroll up and down while you mouse over the interactive map or click the {plus} and {minus} buttons respectively. Alternatively, {tab} focus to the interactive map box and then press the {plus} or {minus} keys. To zoom out to the maximum map extent, press the \"zoom to globe\" button.",
+    "zooming": "Zooming:"
+  },
+  "table-instructions": {
+    "filtering": "Filtering:",
+    "label": "How to Use: Interactive Table",
+    "paging": "Paging:",
+    "sorting": "Sorting:",
+    "template": "{filtering} To filter the table, type in the search bars at the top of each column or the \"search all\" bar.\n\n{sorting} To sort the table, click on the arrow symbols next to the column headings.\n\n{paging} Change the \"show entries\" dropdown to change how many stations are displayed on the page. Click \"next\" or \"previous\" to show additional pages of the table."
+  },
   "about": {
     "access": {
       "blurb": {
@@ -796,36 +810,23 @@
     "news": "News"
   },
   "contact": {
-    "blurb": [
-      "For answers to technical questions, please consult the ",
-      "Frequently Asked Questions",
-      " section.",
-      "If you do not find answers to your questions or to submit your comments, suggestions, and ideas about ",
-      ", please fill out the form below.",
-      "If you have difficulty with the following form, you can use any of our ",
-      "other service channels",
-      " to contact us."
-    ],
+    "blurb": {
+      "channels": "other service channels",
+      "faq": "Frequently Asked Questions",
+      "template": "For answers to technical questions, please consult the {faq} section.\nIf you do not find answers to your questions or to submit your comments, suggestions, and ideas about {woudc}, please fill out the form below.\nIf you have difficulty with the following form, you can use any of our {channels} to contact us."
+    },
     "contact-info": "Your Contact Information",
     "contact-methods": {
-      "By Mail": [
-        "World Ozone and Ultraviolet Radiation Data Centre",
-        "Meteorological Service of Canada",
-        "Environment and Climate Change Canada",
-        "4905 Dufferin Street",
-        "Toronto, ON M3H 5T4",
-        "Canada"
-      ]
+      "By Mail": "World Ozone and Ultraviolet Radiation Data Centre\nMeteorological Service of Canada\nEnvironment and Climate Change Canada\n4905 Dufferin Street\nToronto, ON M3H 5T4\nCanada"
     },
     "email": "E-mail Address",
     "message": "Message",
     "name": "Name",
-    "note-body": [
-      "All personal information created, held or collected by this department is protected under the ",
-      "Privacy Act",
-      ". This means that you will be informed of the purpose for which it is being collected and how to exercise your right of access to that information. You will be asked for your consent where appropriate."
-    ],
-    "note-title": "Personal Information Collection Statement",
+    "note": {
+      "privacy": "Privacy Act",
+      "template": "All personal information created, held or collected by this department is protected under the {privacy}. This means that you will be informed of the purpose for which it is being collected and how to exercise your right of access to that information. You will be asked for your consent where appropriate.",
+      "title": "Personal Information Collection Statement"
+    },
     "other-channels": "Other Service Channels",
     "prompt": "Please provide information that we could use to contact you.",
     "required": "required",
@@ -837,30 +838,22 @@
   "contributors": {
     "list": {
       "blurb": "The contributor list provides the institute or organization name and abbreviation, address, contact information and local file information.",
-      "contributor-headers": [
-        "Acronym",
-        "Project",
-        "Contributor Name",
-        "Country",
-        "Date From",
-        "Date To",
-        "WMO Region"
-      ],
-      "deployment-headers": [
-        "WOUDC Station ID",
-        "Station Name",
-        "Station Type",
-        "Station Country",
-        "Date From",
-        "Date To"
-      ],
-      "map-instructions": {
-        "label": "How to Use: Interactive Map",
-        "text": "Lorem Ipsum something something something"
+      "contributor-headers": {
+        "acronym": "Acronym",
+        "country": "Country",
+        "end_date": "Date To",
+        "name": "Contributor Name",
+        "project": "Project",
+        "start_date": "Date From",
+        "wmo_region_id": "WMO Region"
       },
-      "table-instructions": {
-        "label": "How to Use: Interactive Table",
-        "text": "Lorem Ipsum something something something"
+      "deployment-headers": {
+        "country": "Station Country",
+        "end_date": "Date To",
+        "name": "Station Name",
+        "start_date": "Date From",
+        "type": "Station Type",
+        "woudc_id": "WOUDC Station ID"
       },
       "title": "Contributor List"
     },
@@ -942,25 +935,55 @@
     ],
     "title": "Data",
     "explore": {
-      "blurb": [
-        "The WOUDC data archive can be searched by data category: there are six ozone data categories and three ultraviolet (UV) radiation data categories. The ozone datasets for total column ozone include total ozone and total ozone observations and the vertical ozone profile includes lidar, ozonesonde, Umkehr N-value and C-Umkehr. The UV datasets for UV irradiance include broadband, multiband and spectral.",
-        "To search and download data, select the dataset and observation time period. Optionally, draw your map extent of interest and then hit search. All available data for that time period will be displayed.",
-        "For more details on how to use this page, please view the ",
-        "How to Use",
-        "guide."
-      ],
-      "country": "Country",
-      "dataset": "Dataset",
-      "instrument": "Instrument",
+      "blurb": {
+        "access": "How to Use",
+        "template": "The WOUDC data archive can be searched by data category: there are six ozone data categories and three ultraviolet (UV) radiation data categories. The ozone datasets for total column ozone include total ozone and total ozone observations and the vertical ozone profile includes lidar, ozonesonde, Umkehr N-value and C-Umkehr. The UV datasets for UV irradiance include broadband, multiband and spectral.\n\nTo search and download data, select the dataset and observation time period. Optionally, draw your map extent of interest and then hit search. All available data for that time period will be displayed.\n\nFor more details on how to use this page, please view the {access} guide."
+      },
+      "country": {
+        "placeholder": "Select a Country",
+        "title": "Country"
+      },
+      "dataset": {
+        "all": "All WOUDC Datasets",
+        "placeholder": "Select a Dataset",
+        "title": "Dataset",
+        "data-centers": {
+          "label": "Related Data Centers",
+          "totalozone": "NDACC: Total Column Ozone",
+          "uv-irradiance": "NDACC: UV Irradiance",
+          "vertical-ozone": "NDACC: Vertical Ozone Profile"
+        },
+        "totalozone": {
+          "daily": "Total Ozone - Daily Observations",
+          "hourly": "Total Ozone - Hourly Observations",
+          "label": "Total Column Ozone"
+        },
+        "uv-irradiance": {
+          "broadband": "Broadband",
+          "label": "UV Irradiance",
+          "multiband": "Multiband",
+          "spectral": "Spectral",
+          "uv-index": "UV Index"
+        },
+        "vertical-ozone": {
+          "label": "Vertical Ozone Profile",
+          "lidar": "Lidar",
+          "ozonesonde": "OzoneSonde",
+          "rocketsonde": "RocketSonde",
+          "umkehr1": "UmkehrN14 (Level 1.0)",
+          "umkehr2": "UmkehrN14 (Level 2.0)"
+        }
+      },
       "end": "End",
-      "placeholders": {
-        "country": "Select a Country",
-        "dataset": "Select a Dataset",
-        "instrument": "Select an Instrument",
-        "station": "Select a Station"
+      "instrument": {
+        "placeholder": "Select an Instrument",
+        "title": "Instrument"
       },
       "start": "Start",
-      "station": "Station",
+      "station": {
+        "placeholder": "Select a Station",
+        "title": "Station"
+      },
       "title": "Data Search / Download"
     },
     "info": {
@@ -998,23 +1021,15 @@
     },
     "instruments": {
       "blurb": "The WOUDC data archive can be sorted by instrument. The instrument list includes the instrument type, name and model.",
-      "headers": [
-        "Instrument Type",
-        "Instrument Model",
-        "Date From",
-        "Date To",
-        "Data Class",
-        "Data Category",
-        "Station Name",
-        "Web Accessible Folder"
-      ],
-      "map-instructions": {
-        "label": "How to Use: Interactive Map",
-        "text": "Lorem Ipsum something something something"
-      },
-      "table-instructions": {
-        "label": "How to Use: Interactive Table",
-        "text": "Lorem Ipsum something something something"
+      "headers": {
+        "data_class": "Data Class",
+        "dataset": "Data Category",
+        "end_date": "Date To",
+        "model": "Instrument Model",
+        "name": "Instrument Type",
+        "start_date": "Date From",
+        "station": "Station Name",
+        "waf_url": "Web Accessible Folder"
       },
       "title": "Instrument List"
     },
@@ -1068,41 +1083,33 @@
     },
     "stations": {
       "blurb": "The WOUDC data archive can be sorted by station. To find out the identifying number of a particular station, select the metadata link on the WOUDC website and then the region that you are interested in. All available stations and their numbers for that region will then be displayed.",
-      "deployment-headers": [
-        "Acronym",
-        "Project",
-        "Contributor Name",
-        "Date From",
-        "Date To"
-      ],
-      "instrument-headers": [
-        "Instrument Type",
-        "Instrument Model",
-        "Instrument Number",
-        "Date From",
-        "Date To",
-        "Data Class",
-        "Data Category",
-        "Web Accessible Folder"
-      ],
-      "map-instructions": {
-        "label": "How to Use: Interactive Map",
-        "text": "Lorem Ipsum something something something"
+      "deployment-headers": {
+        "acronym": "Acronym",
+        "end_date": "Date To",
+        "name": "Contributor Name",
+        "project": "Project",
+        "start_date": "Date From"
       },
-      "station-headers": [
-        "WOUDC Station ID",
-        "GAW ID",
-        "Date From",
-        "Date To",
-        "Station Name",
-        "Station Country",
-        "Revision Date",
-        "Station Type",
-        "WMO Region"
-      ],
-      "table-instructions": {
-        "label": "How to Use: Interactive Table",
-        "text": "Lorem Ipsum something something something"
+      "instrument-headers": {
+        "data_class": "Data Class",
+        "dataset": "Data Category",
+        "end_date": "Date To",
+        "model": "Instrument Model",
+        "name": "Instrument Type",
+        "serial": "Instrument Number",
+        "start_date": "Date From",
+        "waf_url": "Web Accessible Folder"
+      },
+      "station-headers": {
+        "woudc_id": "WOUDC Station ID",
+        "gaw_id": "GAW ID",
+        "start_date": "Date From",
+        "end_date": "Date To",
+        "name": "Station Name",
+        "country": "Station Country",
+        "last_validated_datetime": "Revision Date",
+        "type": "Station Type",
+        "wmo_region_id": "WMO Region"
       },
       "title": "Station List"
     }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -7,6 +7,20 @@
   "wmo": "OMM",
   "wmoFull": "Organisation météorologique mondiale",
   "woudcFull": "Centre mondial de données sur l’ozone et le rayonnement ultraviolet",
+  "map-instructions": {
+    "label": "Guide d'utilisation : Carte interactive",
+    "panning": "Déplacement :",
+    "tab": "tabulation (TAB)",
+    "template": "{panning} Cliquez sur n'importe quelle partie de la carte interactive et faites-la glisser. Ou alors, déplacer le curseur sur la fenêtre de la carte avec la touche {tab} et déplacez-vous à l’aide des touches fléchées.\n\n{zooming} Pour agrandir ou réduire la vue, servez-vous de la roulette de votre souris lorsque votre curseur se trouve sur la carte, ou cliquez sur la {plus} ou la touche {minus}. Ou alors, déplacez le curseur sur la fenêtre de la carte avec la touche {tab} et cliquez sur la {plus} ou la touche {minus}. Pour effectuer un zoom arrière complet, appuyez sur le bouton \"Voir le globe\".",
+    "zooming": "Zoom :"
+  },
+  "table-instructions": {
+    "filtering": "Filtrer :",
+    "label": "Guide d'utilisation : Tableau interactif",
+    "paging": "Pagination :",
+    "sorting": "Trier :",
+    "template": "{filtering} Pour filtrer le tableau, indiquez les termes dans la barre de recherche en haut de chaque colonne ou la barre \"rechercher tout\".\n\n{sorting} Pour trier le tableau, cliquez sur les flèches à côté des intitulés des colonnes.\n\n{paging} Changer l'option \"voir les entrées\" dans la liste déroulante pour changer le nombre de stations à afficher sur la page. Cliquez sur \"suivant\" ou \"précédent\" pour afficher plus de pages du tableau."
+  },
   "about": {
     "access": {
       "blurb": {
@@ -801,36 +815,23 @@
     "news": "Nouvelles"
   },
   "contact": {
-    "blurb": [
-      "Pour les questions techniques, consultez la ",
-      "Foire aux questions",
-      ".",
-      "Si vous ne trouvez pas de réponse à vos questions, ou si vous désirez nous faire part de vos commentaires, suggestions ou idées à propos du ",
-      ", veuillez remplir le formulaire ci-dessous.",
-      "Si vous avez des problèmes avec le formulaire suivant, vous pouvez utiliser une des ",
-      "autres voies de service",
-      " pour communiquer avec nous."
-    ],
+    "blurb": {
+      "channels": "autres voies de service",
+      "faq": "Foire aux questions",
+      "template": "Pour les questions techniques, consultez la {faq}.\nSi vous ne trouvez pas de réponse à vos questions, ou si vous désirez nous faire part de vos commentaires, suggestions ou idées à propos du {woudc}, veuillez remplir le formulaire ci-dessous.\nSi vous avez des problèmes avec le formulaire suivant, vous pouvez utiliser une des {channels} pour communiquer avec nous."
+    },
     "contact-info": "Vos Coordonnées",
     "contact-methods": {
-      "Par la poste": [
-        "Centre mondial de données sur l’ozone et le rayonnement ultraviolet",
-        "Services météorologiques du Canada",
-        "Environnement et Changement climatique Canada",
-        "4905, rue Dufferin",
-        "Toronto, ON M3H 5T4",
-        "Canada"
-      ]
+      "Par la poste": "Centre mondial de données sur l’ozone et le rayonnement ultraviolet\nServices météorologiques du Canada\nEnvironnement et Changement climatique Canada\n4905, rue Dufferin\nToronto, ON M3H 5T4\nCanada"
     },
     "email": "Courriel",
     "message": "Message",
     "name": "Nom",
-    "note-body": [
-      "Tous les renseignements personnels créés, recueillis ou conservés par le ministère sont protégés par la ",
-      "Loi sur la protection des renseignements personnels",
-      ". Cela signifie qu'on vous informera des fins auxquelles ces renseignements sont recueillis et de la façon dont vous pouvez exercer votre droit d'accès à ces renseignements. Le cas échéant, on vous demandera d'exprimer votre consentement par rapport à ces renseignements."
-    ],
-    "note-title": "Énoncé de collecte de renseignements personnels",
+    "note": {
+      "privacy": "Loi sur la protection des renseignements personnels",
+      "template": "Tous les renseignements personnels créés, recueillis ou conservés par le ministère sont protégés par la {privacy}. Cela signifie qu'on vous informera des fins auxquelles ces renseignements sont recueillis et de la façon dont vous pouvez exercer votre droit d'accès à ces renseignements. Le cas échéant, on vous demandera d'exprimer votre consentement par rapport à ces renseignements.",
+      "title": "Énoncé de collecte de renseignements personnels"
+    },
     "other-channels": "Autres voies de service",
     "prompt": "S'il vous plaît fournir des informations que nous pourrions utiliser pour communiquer avec vous.",
     "required": "obligatoire",
@@ -842,30 +843,22 @@
   "contributors": {
     "list": {
       "blurb": "La liste des contributeurs contient le nom et l’abréviation de l’institut ou de l’organisation,l’adresse, les coordonnées et l’information sur le fichier local.",
-      "contributor-headers": [
-        "Acronyme",
-        "Project title in French",
-        "Nom du contributeur",
-        "Pays",
-        "À partir de cette date",
-        "Jusqu’à cette date",
-        "Région de l'OMM"
-      ],
-      "deployment-headers": [
-        "Identification de la station du WOUDC",
-        "Nom de la station",
-        "Type de station",
-        "Pays de la station",
-        "À partir de cette date",
-        "Jusqu’à cette date"
-      ],
-      "map-instructions": {
-        "label": "Guide d'utilisation : Carte interactive",
-        "text": "Lorem Ipsum something something something"
+      "contributor-headers": {
+        "acronym": "Acronyme",
+        "country": "Pays",
+        "end_date": "Jusqu’à cette date",
+        "name": "Nom du contributeur",
+        "project": "Projet",
+        "start_date": "À partir de cette date",
+        "wmo_region_id": "Région de l'OMM"
       },
-      "table-instructions": {
-        "label": "Guide d'utilisation : Tableau interactif",
-        "text": "Lorem Ipsum something something something"
+      "deployment-headers": {
+        "country": "Pays de la station",
+        "end_date": "Jusqu’à cette date",
+        "name": "Nom de la station",
+        "start_date": "À partir de cette date",
+        "type": "Type de station",
+        "woudc_id": "Identification de la station du WOUDC"
       },
       "title": "Liste des contributeurs"
     },
@@ -947,25 +940,55 @@
     ],
     "title": "Données",
     "explore": {
-      "blurb": [
-        "La recherche dans l’archive de données du WOUDC peut se faire par catégorie de données : il y a six catégories de données sur l’ozone et trois sur le rayonnement ultraviolet (UV). Les jeux de données pour la colonne d’ozone totale comprennent l’ozone total et les observations sur l’ozone total, et la courbe de répartition verticale de l’ozone comprend les valeurs obtenues à l’aide des techniques lidar et des sondages d’ozone, ainsi que les valeurs N obtenues à l’aide de la technique Umkehr et celles établies à l’aide de la technique C-Umkehr. Les jeux de données sur le rayonnement UV comprennent celles à large bande, multibandes, et spectrales.",
-        "Pour chercher et télécharger des données, sélectionnez l’ensemble de données et la période d’observation. Vous pouvez également choisir l’étendue géographique de votre recherche et cliquer sur envoyer la requête. Toutes les données disponibles pour cette période seront affichées.",
-        "Pour obtenir plus d’information à propos de l’utilisation de cette page, consultez le ",
-        "Guide d’utilisation",
-        "."
-      ],
-      "country": "Pays",
-      "dataset": "Jeu de Données",
-      "instrument": "Instrument",
-      "end": "Fin",
-      "placeholders": {
-        "country": "Select a Country in French",
-        "dataset": "Select a Dataset in French",
-        "instrument": "Select an Instrument in French",
-        "station": "Select a Station in French"
+      "blurb": {
+        "access": "Guide d’utilisation",
+        "template": "La recherche dans l’archive de données du WOUDC peut se faire par catégorie de données : il y a six catégories de données sur l’ozone et trois sur le rayonnement ultraviolet (UV). Les jeux de données pour la colonne d’ozone totale comprennent l’ozone total et les observations sur l’ozone total, et la courbe de répartition verticale de l’ozone comprend les valeurs obtenues à l’aide des techniques lidar et des sondages d’ozone, ainsi que les valeurs N obtenues à l’aide de la technique Umkehr et celles établies à l’aide de la technique C-Umkehr. Les jeux de données sur le rayonnement UV comprennent celles à large bande, multibandes, et spectrales.\n\nPour chercher et télécharger des données, sélectionnez l’ensemble de données et la période d’observation. Vous pouvez également choisir l’étendue géographique de votre recherche et cliquer sur envoyer la requête. Toutes les données disponibles pour cette période seront affichées.\n\nPour obtenir plus d’information à propos de l’utilisation de cette page, consultez le {access}."
       },
+      "country": {
+        "placeholder": "Choisis un Pays",
+        "title": "Pays"
+      },
+      "dataset": {
+        "all": "Tous les ensembles de données de WOUDC",
+        "placeholder": "Choisis un Jeu de Données",
+        "title": "Jeu de Données",
+        "data-centers": {
+          "label": "Centres de données connexes",
+          "totalozone": "Colonne d'ozone total",
+          "uv-irradiance": "Rayonnement UV",
+          "vertical-ozone": "Courbe de réparition verticale de l'ozone"
+        },
+        "totalozone": {
+          "daily": "Ozone total - Observations quotidiennes",
+          "hourly": "Ozone total - Observations horaires",
+          "label": "Colonne d'ozone total"
+        },
+        "uv-irradiance": {
+          "broadband": "Large bande",
+          "label": "Rayonnement UV",
+          "multiband": "Multibande",
+          "spectral": "Spectrale",
+          "uv-index": "Indice UV"
+        },
+        "vertical-ozone": {
+          "label": "Courbe de réparition verticale de l'ozone",
+          "lidar": "Lidar",
+          "ozonesonde": "Sonde pour l'ozone",
+          "rocketsonde": "RocketSonde",
+          "umkehr1": "UmkehrN14 (Niveau 1.0)",
+          "umkehr2": "UmkehrN14 (Niveau 2.0)"
+        }
+      },
+      "instrument": {
+        "placeholder": "Choisis un Instrument",
+        "title": "Instrument"
+      },
+      "end": "Fin",
       "start": "Début",
-      "station": "Station",
+      "station": {
+        "placeholder": "Choisis une Station",
+        "title": "Station"
+      },
       "title": "Rechercher des données / Télécharger"
     },
     "info": {
@@ -1003,23 +1026,15 @@
     },
     "instruments": {
       "blurb": "Les archives de données du WOUDC peuvent être classées par instrument. La liste d’instruments comprend le type d’instrument, le nom et le modèle.",
-      "headers": [
-        "Type d'instrument",
-        "Modèle de l’instrument",
-        "À partir de cette date",
-        "Jusqu’à cette date",
-        "Classe de données",
-        "Catégorie de données",
-        "Nom de la station",
-        "Dossier accessible sur le web"
-      ],
-      "map-instructions": {
-        "label": "Guide d'utilisation : Carte interactive",
-        "text": "Lorem Ipsum something something something"
-      },
-      "table-instructions": {
-        "label": "Guide d'utilisation : Tableau interactif",
-        "text": "Lorem Ipsum something something something"
+      "headers": {
+        "data_class": "Classe de données",
+        "dataset": "Catégorie de données",
+        "end_date": "Jusqu’à cette date",
+        "model": "Modèle de l’instrument",
+        "name": "Type d'instrument",
+        "start_date": "À partir de cette date",
+        "station": "Nom de la station",
+        "waf_url": "Dossier accessible sur le web"
       },
       "title": "Liste des instruments"
     },
@@ -1073,35 +1088,33 @@
     },
     "stations": {
       "blurb": "Les archives de données du WOUDC peuvent être classées par station. Pour connaître le numéro identificateur d’une station, sélectionner le lien des métadonnées sur le site Web du WOUDC, puis la région désirée. Vous pourrez ensuite consulter la liste des stations et leur numéro d’identification.",
-      "deployment-headers": [],
-      "instrument-headers": [
-        "Type d'instrument",
-        "Modèle de l’instrument",
-        "Numéro de l’instrument",
-        "À partir de cette date",
-        "Jusqu’à cette date",
-        "Classe de données",
-        "Catégorie de données",
-        "Dossier accessible sur le web"
-      ],
-      "map-instructions": {
-        "label": "Guide d'utilisation : Carte interactive",
-        "text": "Lorem Ipsum something something something"
+      "deployment-headers": {
+        "acronym": "Acronyme",
+        "end_date": "Jusqu’à cette date",
+        "name": "Nom du contributeur",
+        "project": "Projet",
+        "start_date": "À partir de cette date"
       },
-      "station-headers": [
-        "Identification de la station du WOUDC",
-        "Identifiant VAG",
-        "À partir de cette date",
-        "Jusqu’à cette date",
-        "Nom de la station",
-        "Pays de la station",
-        "Date de révision",
-        "Type de station",
-        "Région de l'OMM"
-      ],
-      "table-instructions": {
-        "label": "Guide d'utilisation : Tableau interactif",
-        "text": "Lorem Ipsum something something something"
+      "instrument-headers": {
+        "data_class": "Classe de données",
+        "dataset": "Catégorie de données",
+        "end_date": "Jusqu’à cette date",
+        "model": "Modèle de l’instrument",
+        "name": "Type d'instrument",
+        "serial": "Numéro de l’instrument",
+        "start_date": "À partir de cette date",
+        "waf_url": "Dossier accessible sur le web"
+      },
+      "station-headers": {
+        "woudc_id": "Identification de la station du WOUDC",
+        "gaw_id": "Identifiant VAG",
+        "start_date": "À partir de cette date",
+        "end_date": "Jusqu’à cette date",
+        "name": "Nom de la station",
+        "country": "Pays de la station",
+        "last_validated_datetime": "Date de révision",
+        "type": "Type de station",
+        "wmo_region_id": "Région de l'OMM"
       },
       "title": "Liste des stations"
     }

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -1,7 +1,17 @@
 <template>
   <v-layout justify-center column align-content-center>
     <h1>{{ $t('contact.title') }}</h1>
-    <woudc-blurb :items="blurb" />
+    <i18n class="newlines" path="contact.blurb.template" tag="p">
+      <template v-slot:faq>
+        <nuxt-link :to="localePath('about-faq')" v-text="$t('contact.blurb.faq')" />
+      </template>
+      <template v-slot:woudc>
+        <b>WOUDC</b>
+      </template>
+      <template v-slot:channels>
+        <nuxt-link to="#other-contacts" v-text="$t('contact.blurb.channels')" />
+      </template>
+    </i18n>
     <hr>
     <span class="headline">{{ $t('contact.contact-info') }}</span>
     <p>{{ $t('contact.prompt') }}</p>
@@ -15,7 +25,20 @@
       {{ $t('contact.email') }} <span class="red--text">({{ $t('contact.required') }})</span>
     </h4>
     <v-text-field v-model="selectedEmail" solo />
-    <woudc-note :title="$t('contact.note-title')" :body="noteBody" />
+    <v-card class="mt-1 mb-4" color="info">
+      <v-card-title class="pt-3 pb-0">
+        {{ $t('contact.note.title') }}
+      </v-card-title>
+      <v-card-text>
+        <i18n path="contact.note.template" tag="span">
+          <template v-slot:privacy-act>
+            <i><a href="https://laws-lois.justice.gc.ca/eng/acts/P-21/index.html" target="_blank">
+              {{ $t('contact.note.privacy-act') }}
+            </a></i>
+          </template>
+        </i18n>
+      </v-card-text>
+    </v-card>
     <h4>
       <span class="red--text">*</span>
       {{ $t('contact.subject') }} <span class="red--text">({{ $t('contact.required') }})</span>
@@ -28,49 +51,24 @@
     <v-textarea v-model="selectedMessage" solo />
     <div id="other-contacts">
       <h2>{{ $t('contact.other-channels') }}</h2>
-      <div v-for="(lines, header) in $t('contact.contact-methods')" :key="header">
+      <div v-for="(line, header) in $t('contact.contact-methods')" :key="header">
         <h4>{{ header }}:</h4>
-        <div v-for="(line, i) in lines" :key="i">
+        <p class="newlines">
           {{ line }}
-        </div>
+        </p>
       </div>
     </div>
   </v-layout>
 </template>
 
 <script>
-import WoudcBlurb from '~/components/WoudcBlurb'
-import WoudcNote from '~/components/WoudcNote'
-
 export default {
-  components: {
-    'woudc-blurb': WoudcBlurb,
-    'woudc-note': WoudcNote
-  },
   data() {
     return {
-      selectedName: '',
-      selectedEmail: '',
-      selectedSubject: '',
-      selectedMessage: '',
-      blurb: [
-        { text: this.$t('contact.blurb[0]') },
-        { link: { to: 'about-faq', text: this.$t('contact.blurb[1]') } },
-        { text: this.$t('contact.blurb[2]') },
-        { newlines: 2 },
-        { text: this.$t('contact.blurb[3]') },
-        { bold: 'WOUDC' },
-        { text: this.$t('contact.blurb[4]') },
-        { newlines: 2 },
-        { text: this.$t('contact.blurb[5]') },
-        { link: { to: 'contact', selector: '#other-contacts', text: this.$t('contact.blurb[6]') } },
-        { text: this.$t('contact.blurb[7]') }
-      ],
-      noteBody: [
-        { text: this.$t('contact.note-body[0]') },
-        { italic: { link: { to: 'https://laws-lois.justice.gc.ca/eng/acts/P-21/index.html', type: 'external', text: this.$t('contact.note-body[1]') } } },
-        { text: this.$t('contact.note-body[2]') }
-      ]
+      selectedName: null,
+      selectedEmail: null,
+      selectedSubject: null,
+      selectedMessage: null
     }
   },
   nuxtI18n: {

--- a/pages/contributors/_id.vue
+++ b/pages/contributors/_id.vue
@@ -8,20 +8,46 @@
     <v-expansion-panels id="map-instructions">
       <v-expansion-panel>
         <v-expansion-panel-header>
-          <b>{{ $t('contributors.list.map-instructions.label') }}</b>
+          <b>{{ $t('map-instructions.label') }}</b>
         </v-expansion-panel-header>
         <v-expansion-panel-content>
-          {{ $t('contributors.list.map-instructions.text') }}
+          <i18n class="newlines" path="map-instructions.template" tag="p">
+            <template v-slot:panning>
+              <b>{{ $t('map-instructions.panning') }}</b>
+            </template>
+            <template v-slot:zooming>
+              <b>{{ $t('map-instructions.zooming') }}</b>
+            </template>
+            <template v-slot:tab>
+              <kbd>{{ $t('map-instructions.tab') }}</kbd>
+            </template>
+            <template v-slot:plus>
+              <kbd>+</kbd>
+            </template>
+            <template v-slot:minus>
+              <kbd>-</kbd>
+            </template>
+          </i18n>
         </v-expansion-panel-content>
       </v-expansion-panel>
     </v-expansion-panels>
     <v-expansion-panels id="table-instructions">
       <v-expansion-panel>
         <v-expansion-panel-header>
-          <b>{{ $t('contributors.list.table-instructions.label') }}</b>
+          <b>{{ $t('table-instructions.label') }}</b>
         </v-expansion-panel-header>
         <v-expansion-panel-content>
-          {{ $t('contributors.list.table-instructions.text') }}
+          <i18n class="newlines" path="table-instructions.template" tag="p">
+            <template v-slot:filtering>
+              <b>{{ $t('table-instructions.filtering') }}</b>
+            </template>
+            <template v-slot:sorting>
+              <b>{{ $t('table-instructions.sorting') }}</b>
+            </template>
+            <template v-slot:paging>
+              <b>{{ $t('table-instructions.paging') }}</b>
+            </template>
+          </i18n>
         </v-expansion-panel-content>
       </v-expansion-panel>
     </v-expansion-panels>
@@ -72,24 +98,6 @@
 
 <script>
 import axios from '~/plugins/axios'
-
-const contributorKeys = [
-  'acronym',
-  'project',
-  'name',
-  'country',
-  'start_date',
-  'end_date',
-  'wmo_region_id'
-]
-const deploymentKeys = [
-  'woudc_id',
-  'name',
-  'type',
-  'country',
-  'start_date',
-  'end_date'
-]
 
 export default {
   async validate({ params }) {
@@ -146,18 +154,37 @@ export default {
   },
   computed: {
     contributorHeaders() {
-      return [...contributorKeys.keys()].map((index) => {
+      const contributorKeys = [
+        'acronym',
+        'project',
+        'name',
+        'country',
+        'start_date',
+        'end_date',
+        'wmo_region_id'
+      ]
+
+      return contributorKeys.map((key) => {
         return {
-          text: this.$t('contributors.list.contributor-headers[' + index + ']'),
-          value: contributorKeys[index]
+          text: this.$t('contributors.list.contributor-headers.' + key),
+          value: key
         }
       })
     },
     deploymentHeaders() {
-      return [...deploymentKeys.keys()].map((index) => {
+      const deploymentKeys = [
+        'woudc_id',
+        'name',
+        'type',
+        'country',
+        'start_date',
+        'end_date'
+      ]
+
+      return deploymentKeys.map((key) => {
         return {
-          text: this.$t('contributors.list.deployment-headers[' + index + ']'),
-          value: deploymentKeys[index]
+          text: this.$t('contributors.list.deployment-headers.' + key),
+          value: key
         }
       })
     }

--- a/pages/contributors/index.vue
+++ b/pages/contributors/index.vue
@@ -5,20 +5,46 @@
     <v-expansion-panels id="map-instructions">
       <v-expansion-panel>
         <v-expansion-panel-header>
-          <b>{{ $t('contributors.list.map-instructions.label') }}</b>
+          <b>{{ $t('map-instructions.label') }}</b>
         </v-expansion-panel-header>
         <v-expansion-panel-content>
-          {{ $t('contributors.list.map-instructions.text') }}
+          <i18n class="newlines" path="map-instructions.template" tag="p">
+            <template v-slot:panning>
+              <b>{{ $t('map-instructions.panning') }}</b>
+            </template>
+            <template v-slot:zooming>
+              <b>{{ $t('map-instructions.zooming') }}</b>
+            </template>
+            <template v-slot:tab>
+              <kbd>{{ $t('map-instructions.tab') }}</kbd>
+            </template>
+            <template v-slot:plus>
+              <kbd>+</kbd>
+            </template>
+            <template v-slot:minus>
+              <kbd>-</kbd>
+            </template>
+          </i18n>
         </v-expansion-panel-content>
       </v-expansion-panel>
     </v-expansion-panels>
     <v-expansion-panels id="table-instructions">
       <v-expansion-panel>
         <v-expansion-panel-header>
-          <b>{{ $t('contributors.list.table-instructions.label') }}</b>
+          <b>{{ $t('table-instructions.label') }}</b>
         </v-expansion-panel-header>
         <v-expansion-panel-content>
-          {{ $t('contributors.list.table-instructions.text') }}
+          <i18n class="newlines" path="table-instructions.template" tag="p">
+            <template v-slot:filtering>
+              <b>{{ $t('table-instructions.filtering') }}</b>
+            </template>
+            <template v-slot:sorting>
+              <b>{{ $t('table-instructions.sorting') }}</b>
+            </template>
+            <template v-slot:paging>
+              <b>{{ $t('table-instructions.paging') }}</b>
+            </template>
+          </i18n>
         </v-expansion-panel-content>
       </v-expansion-panel>
     </v-expansion-panels>
@@ -48,16 +74,6 @@
 <script>
 import axios from '~/plugins/axios'
 
-const contributorKeys = [
-  'acronym',
-  'project',
-  'name',
-  'country',
-  'start_date',
-  'end_date',
-  'wmo_region_id'
-]
-
 export default {
   async asyncData({ params }) {
     const contributorsURL = '/collections/contributors/items'
@@ -82,10 +98,20 @@ export default {
   },
   computed: {
     headers() {
-      return [...contributorKeys.keys()].map((index) => {
+      const contributorKeys = [
+        'acronym',
+        'project',
+        'name',
+        'country',
+        'start_date',
+        'end_date',
+        'wmo_region_id'
+      ]
+
+      return contributorKeys.map((key) => {
         return {
-          text: this.$t('contributors.list.contributor-headers[' + index + ']'),
-          value: contributorKeys[index]
+          text: this.$t('contributors.list.contributor-headers.' + key),
+          value: key
         }
       })
     }

--- a/pages/data/explore.vue
+++ b/pages/data/explore.vue
@@ -1,38 +1,59 @@
 <template>
   <v-layout justify-center column align-content-center>
     <h1>{{ $t('data.explore.title') }}</h1>
-    <woudc-blurb :items="blurb" />
-    <h3>{{ $t('data.explore.dataset') }}</h3>
-    <woudc-select
-      v-model="selectedDataset"
-      :options="datasets"
-      :placeholder="$t('data.explore.placeholders.dataset')"
+    <i18n class="newlines" path="data.explore.blurb.template" tag="p">
+      <template v-slot:access>
+        <nuxt-link
+          :to="localePath('about-dataaccess')"
+          v-text="$t('data.explore.blurb.access')"
+        />
+      </template>
+    </i18n>
+    <h3>{{ $t('data.explore.dataset.title') }}</h3>
+    <v-select
+      class="woudc-select"
+      :value="selectedDataset"
+      :items="datasetOptions"
+      :label="$t('data.explore.dataset.placeholder')"
+      item-text="name"
+      item-value="value"
+      solo
       @input="clearAll()"
     />
-    <h3>{{ $t('data.explore.country') }}</h3>
-    <woudc-select
-      v-model="selectedCountry"
-      :options="countries"
-      :placeholder="$t('data.explore.placeholders.country')"
-      :disabled="selectedDataset === ''"
+    <h3>{{ $t('data.explore.country.title') }}</h3>
+    <v-autocomplete
+      :value="selectedCountry"
+      :items="countries"
+      :label="$t('data.explore.country.placeholder')"
+      :item-text="countryText"
+      item-value="country_code"
+      solo
       @input="clearStationAndInstrument()"
     />
-    <h3>{{ $t('data.explore.station') }}</h3>
-    <woudc-select
-      v-model="selectedStation"
-      :options="stations"
-      :placeholder="$t('data.explore.placeholders.station')"
-      :disabled="selectedDataset === ''"
+    <h3>{{ $t('data.explore.station.title') }}</h3>
+    <v-autocomplete
+      :value="selectedStation"
+      :items="stations"
+      :label="$t('data.explore.station.placeholder')"
+      :item-text="stationText"
+      item-value="woudc_id"
+      solo
       @input="clearInstrument()"
     />
-    <h3>{{ $t('data.explore.instrument') }}</h3>
-    <woudc-select
-      v-model="selectedInstrument"
-      :options="instruments"
-      :placeholder="$t('data.explore.placeholders.instrument')"
-      :disabled="instruments.length === 0"
+    <h3>{{ $t('data.explore.instrument.title') }}</h3>
+    <v-select
+      :value="selectedInstrument"
+      :items="instruments"
+      :label="$t('data.explore.instrument.placeholder')"
+      :item-text="instrumentText"
+      item-value="name"
+      solo
     />
-    <v-range-slider v-model="selectedYearRange" :min="minYear" :max="maxYear" />
+    <v-range-slider
+      v-model="selectedYearRange"
+      :min="minSelectableYear"
+      :max="maxSelectableYear"
+    />
     <div id="start-year">
       <h4>{{ $t('data.explore.start') }}</h4>
       <input v-model="selectedYearRange[0]" type="text">
@@ -45,114 +66,177 @@
 </template>
 
 <script>
-import WoudcBlurb from '~/components/WoudcBlurb'
-import WoudcSelect from '~/components/WoudcSelect'
-
-const now = new Date()
-
 export default {
-  components: {
-    'woudc-blurb': WoudcBlurb,
-    'woudc-select': WoudcSelect
-  },
   data() {
     return {
-      blurb: [
-        { text: this.$t('data.explore.blurb[0]') },
-        { newlines: 2 },
-        { text: this.$t('data.explore.blurb[1]') },
-        { newlines: 2 },
-        { text: this.$t('data.explore.blurb[2]') },
-        { link: { to: 'about-dataaccess', text: this.$t('data.explore.blurb[3]') } },
-        { text: this.$t('data.explore.blurb[4]') }
-      ],
-      selectedDataset: '',
-      selectedCountry: '',
-      selectedStation: '',
-      selectedInstrument: '',
-      minYear: 1924,
-      maxYear: now.getFullYear(),
-      selectedYearRange: [1924, now.getFullYear()],
-      datasets: [
-        { text: 'All WOUDC Datasets', key: 'All' },
+      selectedDataset: null,
+      selectedCountry: null,
+      selectedStation: null,
+      selectedInstrument: null,
+      selectedYearRange: [null, null],
+      minSelectableYear: 1924,
+      countries: [
+        { country_code: null },
         {
-          category: 'Total Column Ozone',
-          children: [
-            { text: 'Total Ozone - Daily Observations', key: 'TotalOzone' },
-            { text: 'Total Ozone - Hourly Observations', key: 'TotalOzoneObs' }
-          ]
+          country_name: { en: 'Canada', fr: 'Canada' },
+          country_code: 'CAN'
         },
         {
-          category: 'Vertical Ozone Profile',
-          children: [
-            { text: 'Lidar', value: 'Lidar' },
-            { text: 'OzoneSonde', value: 'OzoneSonde' },
-            { text: 'UmkehrN14 (Level 1.0)', value: 'UmkehrN14_1.0' },
-            { text: 'UmkehrN14 (Level 2.0)', value: 'UmkehrN14_2.0' },
-            { text: 'RocketSonde', value: 'RocketSonde' }
-          ]
+          country_name: { en: 'Nepal', fr: 'Nepal' },
+          country_code: 'NPL'
         },
         {
-          category: 'UV Irradiance',
-          children: [
-            { text: 'Broadband', key: 'Broad-band' },
-            { text: 'Multiband', key: 'Multi-band' },
-            { text: 'Spectral', key: 'Spectral' },
-            { text: 'UV Index', key: 'uv_index_hourly' }
-          ]
-        },
-        {
-          category: 'Related Data Centers',
-          children: [
-            { text: 'NDACC: Total Column Ozone' },
-            { text: 'NDACC: Vertical Ozone Profile' },
-            { text: 'NDACC: UV Irradiance' }
-          ]
+          country_name: { en: 'Mount Kilimanjaro', fr: 'Mount Kilimanjaro' },
+          country_code: 'KMJ'
         }
       ],
-      countries: [
-        { text: 'Canada', key: 'CAN' },
-        { text: 'Nepal', key: 'NPL' },
-        { text: 'Mount Kilimanjaro', key: 'KMJ' }
-      ],
       stations: [
-        { text: 'Alert (018)', key: '018' },
-        { text: 'Edmonton (021)', key: '021' },
-        { text: 'Moosonee (023)', key: '023' },
-        { text: 'Resolute (024)', key: '024' },
-        { text: 'Toronto (065)', key: '065' },
-        { text: 'Goose Bay (076)', key: '076' },
-        { text: 'Churchill (077)', key: '077' },
-        { text: 'Iqaluit (303)', key: '303' },
-        { text: 'Eureka (315)', key: '315' },
-        { text: 'Kelowna (457)', key: '457' }
+        { woudc_id: null },
+        { name: 'Alert', woudc_id: '018' },
+        { name: 'Edmonton', woudc_id: '021' },
+        { name: 'Moosonee', woudc_id: '023' },
+        { name: 'Resolute', woudc_id: '024' },
+        { name: 'Toronto', woudc_id: '065' },
+        { name: 'Goose Bay', woudc_id: '076' },
+        { name: 'Churchill', woudc_id: '077' },
+        { name: 'Iqaluit', woudc_id: '303' },
+        { name: 'Eureka', woudc_id: '315' },
+        { name: 'Kelowna', woudc_id: '457' }
       ],
       instruments: [
-        { text: 'Some Brewer', key: 'brewer' },
-        { text: 'Some Dobson', key: 'dobson' },
-        { text: 'Another Brewer', key: 'also brewer' }
+        { name: null },
+        { name: 'Brewer' },
+        { name: 'Dobson' },
+        { name: 'ECC' }
       ]
     }
   },
+  computed: {
+    datasetOptions() {
+      const datasetSections = {
+        totalozone: {
+          daily: 'TotalOzone',
+          hourly: 'TotalOzoneObs'
+        },
+        'vertical-ozone': {
+          lidar: 'Lidar',
+          ozonesonde: 'OzoneSonde',
+          umkehr1: 'UmkehrN14_1.0',
+          umkehr2: 'UmkehrN14_2.0',
+          rocketsonde: 'RocketSonde'
+        },
+        'uv-irradiance': {
+          broadband: 'Broad-band',
+          multiband: 'Multi-band',
+          spectral: 'Spectral',
+          'uv-index': 'uv_index_hourly'
+        },
+        'data-centers': {
+          totalozone: 'ndacc-total',
+          'vertical-ozone': 'ndacc-vertical',
+          'uv-irradiance': 'ndacc-uv'
+        }
+      }
+
+      const datasetOptions = []
+      datasetOptions.push({
+        name: this.$t('data.explore.dataset.all'),
+        value: 'All',
+      })
+
+      for (const [section, children] of Object.entries(datasetSections)) {
+        datasetOptions.push({
+          header: this.$t('data.explore.dataset.' + section + '.label')
+        })
+        for (const [subsection, id] of Object.entries(children)) {
+          datasetOptions.push({
+            name: this.$t('data.explore.dataset.' + section + '.' + subsection),
+            value: id
+          })
+        }
+      }
+
+      return datasetOptions
+    },
+    maxSelectableYear() {
+      return (new Date()).getFullYear()
+    }
+  },
+  mounted() {
+    this.selectedYearRange = [
+      this.minSelectableYear, this.maxSelectableYear
+    ]
+  },
   methods: {
+    countryText(country) {
+      if (country.country_code === null) {
+        return '...'
+      } else {
+        const name = country.country_name[this.$i18n.locale]
+        return name + ' (' + country.country_code + ')'
+      }
+    },
+    stationText(station) {
+      if (station.woudc_id === null) {
+        return '...'
+      } else {
+        return station.name + ' (' + station.woudc_id + ')'
+      }
+    },
+    instrumentText(instrument) {
+      if (instrument.name === null) {
+        return '...'
+      } else {
+        return instrument.name
+      }
+    },
     clearAll() {
-      this.selectedCountry = ''
-      this.selectedStation = ''
-      this.selectedInstrument = ''
+      this.selectedCountry = null
+      this.selectedStation = null
+      this.selectedInstrument = null
     },
     clearStationAndInstrument() {
-      this.selectedStation = ''
-      this.selectedInstrument = ''
+      this.selectedStation = null
+      this.selectedInstrument = null
     },
     clearInstrument() {
-      this.selectedInstrument = ''
+      this.selectedInstrument = null
     }
   },
   nuxtI18n: {
     paths: {
-      en: '/explore',
-      fr: '/explore-fr'
+      en: '/data/explore',
+      fr: '/donnees/rechercher'
     }
   }
 }
 </script>
+
+<style scoped>
+.v-select-list >>> .v-list {
+  padding: 0px;
+}
+
+.v-select-list >>> .v-subheader {
+  font-weight: bold;
+  background-color: #e4e4e4;
+  max-height: 40px;
+  padding-left: 12px;
+  margin-left: 0px;
+}
+
+.v-select >>> .v-input__slot {
+  max-width: 60%;
+}
+
+.v-select-list >>> .v-list-item {
+  padding-left: 24px;
+}
+
+.v-select-list >>> .v-list-item,
+.v-select-list >>> .v-list-item__content {
+  padding-top: 0px;
+  padding-bottom: 0px;
+  min-height: 32px;
+}
+</style>

--- a/pages/data/instruments.vue
+++ b/pages/data/instruments.vue
@@ -5,20 +5,46 @@
     <v-expansion-panels id="map-instructions">
       <v-expansion-panel>
         <v-expansion-panel-header>
-          <b>{{ $t('data.instruments.map-instructions.label') }}</b>
+          <b>{{ $t('map-instructions.label') }}</b>
         </v-expansion-panel-header>
         <v-expansion-panel-content>
-          {{ $t('data.instruments.map-instructions.text') }}
+          <i18n class="newlines" path="map-instructions.template" tag="p">
+            <template v-slot:panning>
+              <b>{{ $t('map-instructions.panning') }}</b>
+            </template>
+            <template v-slot:zooming>
+              <b>{{ $t('map-instructions.zooming') }}</b>
+            </template>
+            <template v-slot:tab>
+              <kbd>{{ $t('map-instructions.tab') }}</kbd>
+            </template>
+            <template v-slot:plus>
+              <kbd>+</kbd>
+            </template>
+            <template v-slot:minus>
+              <kbd>-</kbd>
+            </template>
+          </i18n>
         </v-expansion-panel-content>
       </v-expansion-panel>
     </v-expansion-panels>
     <v-expansion-panels id="table-instructions">
       <v-expansion-panel>
         <v-expansion-panel-header>
-          <b>{{ $t('data.instruments.table-instructions.label') }}</b>
+          <b>{{ $t('table-instructions.label') }}</b>
         </v-expansion-panel-header>
         <v-expansion-panel-content>
-          {{ $t('data.instruments.table-instructions.text') }}
+          <i18n class="newlines" path="table-instructions.template" tag="p">
+            <template v-slot:filtering>
+              <b>{{ $t('table-instructions.filtering') }}</b>
+            </template>
+            <template v-slot:sorting>
+              <b>{{ $t('table-instructions.sorting') }}</b>
+            </template>
+            <template v-slot:paging>
+              <b>{{ $t('table-instructions.paging') }}</b>
+            </template>
+          </i18n>
         </v-expansion-panel-content>
       </v-expansion-panel>
     </v-expansion-panels>
@@ -28,7 +54,7 @@
       :items="instruments"
       class="elevation-1"
     >
-      <template v-slot:item.station_name="instrument">
+      <template v-slot:item.station="instrument">
         <nuxt-link :to="'/data/stations/' + instrument.item.station_id">
           {{ instrument.item.station_name }}
         </nuxt-link>
@@ -44,17 +70,6 @@
 
 <script>
 import axios from '~/plugins/axios'
-
-const headerKeys = [
-  'name',
-  'model',
-  'start_date',
-  'end_date',
-  'data_class',
-  'dataset',
-  'station',
-  'waf_url'
-]
 
 export default {
   async asyncData({ params }) {
@@ -76,18 +91,29 @@ export default {
   },
   computed: {
     headers() {
-      return [...headerKeys.keys()].map((index) => {
+      const headerKeys = [
+        'name',
+        'model',
+        'start_date',
+        'end_date',
+        'data_class',
+        'dataset',
+        'station',
+        'waf_url'
+      ]
+
+      return headerKeys.map((key) => {
         return {
-          text: this.$t('data.instruments.headers[' + index + ']'),
-          value: headerKeys[index]
+          text: this.$t('data.instruments.headers.' + key),
+          value: key
         }
       })
     }
   },
   nuxtI18n: {
     paths: {
-      en: '/instruments',
-      fr: '/instruments'
+      en: '/data/instruments',
+      fr: '/donnees/instruments'
     }
   }
 }

--- a/pages/data/stations/_id.vue
+++ b/pages/data/stations/_id.vue
@@ -8,20 +8,46 @@
     <v-expansion-panels id="map-instructions">
       <v-expansion-panel>
         <v-expansion-panel-header>
-          <b>{{ $t('data.stations.map-instructions.label') }}</b>
+          <b>{{ $t('map-instructions.label') }}</b>
         </v-expansion-panel-header>
         <v-expansion-panel-content>
-          {{ $t('data.stations.map-instructions.text') }}
+          <i18n class="newlines" path="map-instructions.template" tag="p">
+            <template v-slot:panning>
+              <b>{{ $t('map-instructions.panning') }}</b>
+            </template>
+            <template v-slot:zooming>
+              <b>{{ $t('map-instructions.zooming') }}</b>
+            </template>
+            <template v-slot:tab>
+              <kbd>{{ $t('map-instructions.tab') }}</kbd>
+            </template>
+            <template v-slot:plus>
+              <kbd>+</kbd>
+            </template>
+            <template v-slot:minus>
+              <kbd>-</kbd>
+            </template>
+          </i18n>
         </v-expansion-panel-content>
       </v-expansion-panel>
     </v-expansion-panels>
     <v-expansion-panels id="table-instructions">
       <v-expansion-panel>
         <v-expansion-panel-header>
-          <b>{{ $t('data.stations.table-instructions.label') }}</b>
+          <b>{{ $t('table-instructions.label') }}</b>
         </v-expansion-panel-header>
         <v-expansion-panel-content>
-          {{ $t('data.stations.table-instructions.text') }}
+          <i18n class="newlines" path="table-instructions.template" tag="p">
+            <template v-slot:filtering>
+              <b>{{ $t('table-instructions.filtering') }}</b>
+            </template>
+            <template v-slot:sorting>
+              <b>{{ $t('table-instructions.sorting') }}</b>
+            </template>
+            <template v-slot:paging>
+              <b>{{ $t('table-instructions.paging') }}</b>
+            </template>
+          </i18n>
         </v-expansion-panel-content>
       </v-expansion-panel>
     </v-expansion-panels>
@@ -94,36 +120,6 @@
 <script>
 import axios from '~/plugins/axios'
 
-const stationKeys = [
-  'woudc_id',
-  'gaw_id',
-  'start_date',
-  'end_date',
-  'name',
-  'country',
-  'last_validated_datetime',
-  'type',
-  'wmo_region_id'
-]
-const deploymentKeys = [
-  'acronym',
-  'project',
-  'name',
-  'start_date',
-  'end_date'
-]
-const instrumentKeys = [
-  'name',
-  'model',
-  'serial',
-  'start_date',
-  'end_date',
-  'data_class',
-  'dataset',
-  'waf_url'
-]
-
-
 export default {
   async validate({ params }) {
     const woudcID = params.id
@@ -177,25 +173,64 @@ export default {
   },
   data() {
     return {
-      station: null,
-      stationHeaders: [...stationKeys.keys()].map((index) => {
-        return {
-          text: this.$t('data.stations.station-headers[' + index + ']'),
-          value: stationKeys[index]
-        }
-      }),
       deployments: [],
-      deploymentHeaders: [...deploymentKeys.keys()].map((index) => {
-        return {
-          text: this.$t('data.stations.deployment-headers[' + index + ']'),
-          value: deploymentKeys[index]
-        }
-      }),
       instruments: [],
-      instrumentHeaders: [...instrumentKeys.keys()].map((index) => {
+      station: null
+    }
+  },
+  computed: {
+    deploymentHeaders() {
+      const deploymentKeys = [
+        'acronym',
+        'project',
+        'name',
+        'start_date',
+        'end_date'
+      ]
+
+      return deploymentKeys.map((key) => {
         return {
-          text: this.$t('data.stations.instrument-headers[' + index + ']'),
-          value: instrumentKeys[index]
+          text: this.$t('data.stations.deployment-headers.' + key),
+          value: key
+        }
+      })
+    },
+    instrumentHeaders() {
+      const instrumentKeys = [
+        'name',
+        'model',
+        'serial',
+        'start_date',
+        'end_date',
+        'data_class',
+        'dataset',
+        'waf_url'
+      ]
+
+      return instrumentKeys.map((key) => {
+        return {
+          text: this.$t('data.stations.instrument-headers.' + key),
+          value: key
+        }
+      })
+    },
+    stationHeaders() {
+      const stationKeys = [
+        'woudc_id',
+        'gaw_id',
+        'start_date',
+        'end_date',
+        'name',
+        'country',
+        'last_validated_datetime',
+        'type',
+        'wmo_region_id'
+      ]
+
+      return stationKeys.map((key) => {
+        return {
+          text: this.$t('data.stations.station-headers.' + key),
+          value: key
         }
       })
     }

--- a/pages/data/stations/index.vue
+++ b/pages/data/stations/index.vue
@@ -5,20 +5,46 @@
     <v-expansion-panels id="map-instructions">
       <v-expansion-panel>
         <v-expansion-panel-header>
-          <b>{{ $t('data.stations.map-instructions.label') }}</b>
+          <b>{{ $t('map-instructions.label') }}</b>
         </v-expansion-panel-header>
         <v-expansion-panel-content>
-          {{ $t('data.stations.map-instructions.text') }}
+          <i18n class="newlines" path="map-instructions.template" tag="p">
+            <template v-slot:panning>
+              <b>{{ $t('map-instructions.panning') }}</b>
+            </template>
+            <template v-slot:zooming>
+              <b>{{ $t('map-instructions.zooming') }}</b>
+            </template>
+            <template v-slot:tab>
+              <kbd>{{ $t('map-instructions.tab') }}</kbd>
+            </template>
+            <template v-slot:plus>
+              <kbd>+</kbd>
+            </template>
+            <template v-slot:minus>
+              <kbd>-</kbd>
+            </template>
+          </i18n>
         </v-expansion-panel-content>
       </v-expansion-panel>
     </v-expansion-panels>
     <v-expansion-panels id="table-instructions">
       <v-expansion-panel>
         <v-expansion-panel-header>
-          <b>{{ $t('data.stations.table-instructions.label') }}</b>
+          <b>{{ $t('table-instructions.label') }}</b>
         </v-expansion-panel-header>
         <v-expansion-panel-content>
-          {{ $t('data.stations.table-instructions.text') }}
+          <i18n class="newlines" path="table-instructions.template" tag="p">
+            <template v-slot:filtering>
+              <b>{{ $t('table-instructions.filtering') }}</b>
+            </template>
+            <template v-slot:sorting>
+              <b>{{ $t('table-instructions.sorting') }}</b>
+            </template>
+            <template v-slot:paging>
+              <b>{{ $t('table-instructions.paging') }}</b>
+            </template>
+          </i18n>
         </v-expansion-panel-content>
       </v-expansion-panel>
     </v-expansion-panels>
@@ -45,18 +71,6 @@
 <script>
 import axios from '~/plugins/axios'
 
-const headerKeys = [
-  'woudc_id',
-  'gaw_id',
-  'start_date',
-  'end_date',
-  'name',
-  'country',
-  'last_validated_datetime',
-  'type',
-  'wmo_region_id'
-]
-
 export default {
   async asyncData() {
     const stationsURL = '/collections/stations/items'
@@ -79,19 +93,35 @@ export default {
   },
   data() {
     return {
-      headers: [...headerKeys.keys()].map((index) => {
-        return {
-          text: this.$t('data.stations.station-headers[' + index + ']'),
-          value: headerKeys[index]
-        }
-      }),
       stations: []
+    }
+  },
+  computed: {
+    headers() {
+      const headerKeys = [
+        'woudc_id',
+        'gaw_id',
+        'start_date',
+        'end_date',
+        'name',
+        'country',
+        'last_validated_datetime',
+        'type',
+        'wmo_region_id'
+      ]
+
+      return headerKeys.map((key) => {
+        return {
+          text: this.$t('data.stations.station-headers.' + key),
+          value: key
+        }
+      })
     }
   },
   nuxtI18n: {
     paths: {
-      en: '/stations',
-      fr: '/stations'
+      en: '/data/stations',
+      fr: '/donnees/stations'
     }
   }
 }


### PR DESCRIPTION
Removes all occurrences of the woudc-blurb, woudc-note, woudc-link, and woudc-select components and replaces them with straight-up Vue components in any remaning non-static pages in the project.

Mainly affects list-type pages (e.g. contributors list, stations list) and the search page, as well as the contact page. Does not affect the news page or products/dataset info pages; I'm not clear on how those pages will work just yet.

Intended as part of a cleanup of the translation system, so that blurbs are built using readable component substitution rather than being set up behind-the-scenes by all these custom components. So translations in the JSON files and their uses in the Vue components in non-static pages have been cleaned up too.