### PR TITLE
Mapping Components

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,5 +7,6 @@ OWS_URL=https://geo.woudc.org/ows
 WAF_URL=https://woudc.org/archive
 DEF_URL=https://geo.woudc.org/def
 WPS_URL=https://geo.woudc.org/wps
+WMO_REGIONS_URL=https://cdn.rawgit.com/OGCMetOceanDWG/wmo-ra/master/wmo-ra.geojson
 CODELISTS_URL=https://geo.woudc.org/codelists.xml
 EMAIL_ADDRESS=sample.woudc@email.ca

--- a/components/MapInstructions.vue
+++ b/components/MapInstructions.vue
@@ -31,3 +31,9 @@
     </v-expansion-panel>
   </v-expansion-panels>
 </template>
+
+<script>
+export default {
+  name: 'MapInstructions'
+}
+</script>

--- a/components/SelectableMap.vue
+++ b/components/SelectableMap.vue
@@ -1,0 +1,144 @@
+<template>
+  <client-only>
+    <l-map
+      id="woudc-map"
+      ref="woudc-map"
+      :zoom="startZoom"
+      :center="startCenter"
+      @moveend="emitBoundaryChange"
+    >
+      <l-tile-layer :url="tileURLTemplate" />
+      <l-control class="leaflet-bar" position="topleft">
+        <a class="leaflet-touch" role="button" @click="zoomToGlobe">
+          <v-icon>mdi-earth</v-icon>
+        </a>
+      </l-control>
+      <l-geo-json
+        v-for="region in wmoRegions"
+        :key="region.properties.WMO_RA"
+        :geojson="region"
+        :options="{ style: borderStyle }"
+      />
+      <l-marker
+        v-for="element in elements"
+        :key="element.identifier"
+        :ref="element.identifier + '-marker'"
+        :lat-lng="element.geometry.coordinates"
+        @click="emitSelection(element)"
+        @popupclose="emitSelection(null)"
+      >
+        <l-popup>
+          <slot name="popup" :item="element">
+            {{ element.identifier }}
+          </slot>
+        </l-popup>
+      </l-marker>
+    </l-map>
+  </client-only>
+</template>
+
+<script>
+export default {
+  name: 'SelectableMap',
+  props: {
+    elements: { type: Array, required: true },
+    selected: { type: Object, required: false, default: null }
+  },
+  data() {
+    return {
+      borderStyle: {
+        color: 'darkblue',
+        fillOpacity: 0,
+        weight: 0.8
+      },
+      eventLock: false,
+      startCenter: [ 0, 0 ],
+      startZoom: 1,
+      tileURLTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png'
+    }
+  },
+  computed: {
+    wmoRegions() {
+      const regions = this.$store.getters['wmoRegions/all']
+      return Object.values(regions)
+    }
+  },
+  watch: {
+    selected(newSelection, oldSelection) {
+      if (newSelection === null) {
+        // De-activate old selection (which is necessarily non-null).
+        const markerID = oldSelection.identifier + '-marker'
+        this.$refs[markerID][0].mapObject.closePopup()
+      } else if (oldSelection === null) {
+        // Make a selection when nothing was selected previously.
+        const markerID = newSelection.identifier + '-marker'
+        this.$refs[markerID][0].mapObject.openPopup()
+      } else if (newSelection.identifier !== oldSelection.identifier) {
+        // Change from one selection to a different one.
+        // Block the close popup event from registering as a selection change.
+        this.eventLock = true
+        const oldMarkerID = oldSelection.identifier + '-marker'
+        this.$refs[oldMarkerID][0].mapObject.closePopup()
+        this.eventLock = false
+
+        const newMarkerID = newSelection.identifier + '-marker'
+        this.$refs[newMarkerID][0].mapObject.openPopup()
+      }
+    }
+  },
+  mounted() {
+    this.setIconSize()
+    this.setupWMORegions()
+
+    if (this.selected !== null) {
+      // Zoom in toward the initially selected element.
+      this.startCenter = this.selected.geometry.coordinates
+      this.startZoom = 12
+
+      this.$nextTick(() => {
+        const markerID = this.selected.identifier + '-marker'
+        this.$refs[markerID][0].mapObject.openPopup()
+      })
+    }
+  },
+  methods: {
+    emitBoundaryChange(event) {
+      const bounds = event.target.getBounds()
+      this.$emit('move', bounds)
+    },
+    emitSelection(element) {
+      if (!this.eventLock) {
+        this.$emit('select', element)
+      }
+    },
+    setupWMORegions() {
+      this.$store.dispatch('wmoRegions/download')
+    },
+    // Set the markers icons displayed on the map to a smaller size.
+    setIconSize() {
+      const iconOptions = this.$L.Icon.Default.prototype.options
+
+      iconOptions.iconSize = [ 12.5, 20.5 ]
+      iconOptions.shadowSize = [ 20.5, 20.5 ]
+      iconOptions.iconAnchor = [ 6.25, 20.5 ]
+      iconOptions.popupAnchor = [ 0, -20 ]
+    },
+    zoomToGlobe() {
+      const map = this.$refs['woudc-map']
+      map.mapObject.setView({ lat: 0, lon: 0 }, 1)
+    }
+  }
+}
+</script>
+
+<style>
+#woudc-map {
+  height: 520px;
+  width: 520px;
+  min-width: 520px;
+
+  margin-right: 20px;
+  margin-bottom: 20px;
+  z-index: 0;
+}
+</style>

--- a/components/SelectableTable.vue
+++ b/components/SelectableTable.vue
@@ -1,0 +1,80 @@
+<template>
+  <v-data-table
+    :headers="headers"
+    :hide-default-footer="elements.length < 5"
+    :items="elements"
+    :items-per-page="rowsPerPage"
+    :page="selectedPage"
+    class="elevation-1"
+    @update:items-per-page="rowsPerPage = $event; jumpToSelection()"
+  >
+    <template v-slot:item="row">
+      <tr
+        :class="{ 'selected-row': isSelected(row.item) }"
+        @click="emitSelection(row.item)"
+      >
+        <slot name="row" :item="row.item" />
+      </tr>
+    </template>
+  </v-data-table>
+</template>
+
+<script>
+export default {
+  name: 'SelectableTable',
+  props: {
+    elements: { type: Array, required: true },
+    headers: { type: Array, required: true },
+    selected: { type: Object, required: false, default: null }
+  },
+  data() {
+    return {
+      rowsPerPage: 10,
+      selectedPage: 1
+    }
+  },
+  watch: {
+    elements(newList, oldList) {
+      this.jumpToSelection()
+    },
+    selected(newSelection, oldSelection) {
+      this.jumpToSelection()
+    }
+  },
+  methods: {
+    emitSelection(element) {
+      if (this.selected !== null && element.identifier === this.selected.identifier) {
+        // Deselect if clicking on an already selected element.
+        this.$emit('select', null)
+      } else {
+        // Selecting a new element.
+        this.$emit('select', element)
+      }
+    },
+    isSelected(element) {
+      return this.selected !== null && element.identifier === this.selected.identifier
+    },
+    jumpToSelection() {
+      const index = this.elements.indexOf(this.selected)
+
+      if (index === -1) {
+        const numPages = Math.ceil(this.elements.length / this.rowsPerPage)
+        this.selectedPage = Math.min(this.selectedPage, numPages)
+      } else {
+        const page = Math.ceil((index + 1) / this.rowsPerPage)
+        this.selectedPage = page
+      }
+    }
+  }
+}
+</script>
+
+<style>
+.selected-row {
+  background-color: palegreen;
+}
+
+.selected-row:hover {
+  background-color: lightgreen !important;
+}
+</style>

--- a/components/TableInstructions.vue
+++ b/components/TableInstructions.vue
@@ -24,3 +24,9 @@
     </v-expansion-panel>
   </v-expansion-panels>
 </template>
+
+<script>
+export default {
+  name: 'TableInstructions'
+}
+</script>

--- a/locales/en.json
+++ b/locales/en.json
@@ -828,6 +828,8 @@
         "start_date": "Date From",
         "wmo_region_id": "WMO Region"
       },
+      "contributor-name": "Contributor Name:",
+      "country-name": "Country:",
       "deployment-headers": {
         "country": "Station Country",
         "end_date": "Date To",
@@ -964,6 +966,7 @@
     },
     "instruments": {
       "blurb": "The WOUDC data archive can be sorted by instrument. The instrument list includes the instrument type, name and model.",
+      "contributor-name": "Contributor Name:",
       "headers": {
         "data_class": "Data Class",
         "dataset": "Data Category",
@@ -974,6 +977,8 @@
         "station": "Station Name",
         "waf_url": "Web Accessible Folder"
       },
+      "instrument-type": "Instrument Type:",
+      "station-name": "Station Name:",
       "title": "Instrument List"
     },
     "products": {
@@ -1024,6 +1029,7 @@
     },
     "stations": {
       "blurb": "The WOUDC data archive can be sorted by station. To find out the identifying number of a particular station, select the metadata link on the WOUDC website and then the region that you are interested in. All available stations and their numbers for that region will then be displayed.",
+      "country-name": "Station Country:",
       "deployment-headers": {
         "acronym": "Acronym",
         "end_date": "Date To",
@@ -1031,6 +1037,7 @@
         "project": "Project",
         "start_date": "Date From"
       },
+      "gaw-id": "GAW ID:",
       "instrument-headers": {
         "data_class": "Data Class",
         "dataset": "Data Category",
@@ -1052,6 +1059,8 @@
         "type": "Station Type",
         "wmo_region_id": "WMO Region"
       },
+      "station-id": "WOUDC Station ID:",
+      "station-name": "Station Name:",
       "title": "Station List"
     }
   },

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -829,6 +829,8 @@
         "start_date": "À partir de cette date",
         "wmo_region_id": "Région de l'OMM"
       },
+      "contributor-name": "Nom du contributeur :",
+      "country-name": "Nom du pays :",
       "deployment-headers": {
         "country": "Pays de la station",
         "end_date": "Jusqu’à cette date",
@@ -965,6 +967,7 @@
     },
     "instruments": {
       "blurb": "Les archives de données du WOUDC peuvent être classées par instrument. La liste d’instruments comprend le type d’instrument, le nom et le modèle.",
+      "contributor-name": "Nom du contributeur :",
       "headers": {
         "data_class": "Classe de données",
         "dataset": "Catégorie de données",
@@ -975,6 +978,8 @@
         "station": "Nom de la station",
         "waf_url": "Dossier accessible sur le web"
       },
+      "instrument-type": "Type d’instrument :",
+      "station-name": "Nom de la station :",
       "title": "Liste des instruments"
     },
     "products": {
@@ -1027,6 +1032,7 @@
     },
     "stations": {
       "blurb": "Les archives de données du WOUDC peuvent être classées par station. Pour connaître le numéro identificateur d’une station, sélectionner le lien des métadonnées sur le site Web du WOUDC, puis la région désirée. Vous pourrez ensuite consulter la liste des stations et leur numéro d’identification.",
+      "country-name": "Pays de la station :",
       "deployment-headers": {
         "acronym": "Acronyme",
         "end_date": "Jusqu’à cette date",
@@ -1034,6 +1040,7 @@
         "project": "Projet",
         "start_date": "À partir de cette date"
       },
+      "gaw-id": "Identifiant VAG :",
       "instrument-headers": {
         "data_class": "Classe de données",
         "dataset": "Catégorie de données",
@@ -1055,6 +1062,8 @@
         "type": "Type de station",
         "wmo_region_id": "Région de l'OMM"
       },
+      "station-id": "Identification de la station du WOUDC :",
+      "station-name": "Nom de la station :",
       "title": "Liste des stations"
     }
   },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -60,7 +60,8 @@ export default {
     // Doc: https://axios.nuxtjs.org/usage
     '@nuxtjs/axios',
     '@nuxtjs/pwa',
-    'nuxt-i18n'
+    'nuxt-i18n',
+    'nuxt-leaflet'
   ],
   /*
    ** Axios module configuration

--- a/package.json
+++ b/package.json
@@ -25,9 +25,12 @@
     "@nuxtjs/axios": "^5.9.2",
     "@nuxtjs/pwa": "^3.0.0-0",
     "axios": "^0.19.1",
+    "leaflet": "^1.6.0",
     "nuxt": "^2.11.0",
     "nuxt-i18n": "^6.4.1",
-    "vue-i18n": "^8.15.3"
+    "nuxt-leaflet": "0.0.21",
+    "vue-i18n": "^8.15.3",
+    "vue2-leaflet": "^2.5.2"
   },
   "devDependencies": {
     "@kazupon/vue-i18n-loader": "^0.4.1",

--- a/pages/data/instruments.vue
+++ b/pages/data/instruments.vue
@@ -2,36 +2,74 @@
   <v-layout justify-center column align-content-center>
     <h1>{{ $t('data.instruments.title') }}</h1>
     <p>{{ $t('data.instruments.blurb') }}</p>
-    <map-instructions id="map-instructions" />
-    <table-instructions id="table-instructions" />
-    <v-data-table
-      id="instruments-table"
+    <v-row>
+      <v-col>
+        <selectable-map
+          :elements="instruments"
+          :selected="selectedInstrument"
+          @select="selectedInstrument = $event"
+          @move="boundingBox = $event"
+        >
+          <template v-slot:popup="element">
+            <strong>{{ $t('data.instruments.instrument-type') }}</strong>
+            <span> {{ element.item.name }}</span>
+            <br>
+            <strong>{{ $t('data.instruments.station-name') }}</strong>
+            <nuxt-link :to="'/data/stations/' + element.item.station_id">
+              {{ element.item.station_name }}
+            </nuxt-link>
+            <br>
+            <strong>{{ $t('data.instruments.contributor-name') }}</strong>
+            <span> TODO</span>
+          </template>
+        </selectable-map>
+      </v-col>
+      <v-col>
+        <map-instructions id="map-instructions" />
+        <table-instructions id="table-instructions" />
+      </v-col>
+    </v-row>
+    <selectable-table
       :headers="headers"
-      :items="instruments"
-      class="elevation-1"
+      :elements="visibleInstruments"
+      :selected="selectedInstrument"
+      @select="selectedInstrument = $event"
     >
-      <template v-slot:item.station="instrument">
-        <nuxt-link :to="'/data/stations/' + instrument.item.station_id">
-          {{ instrument.item.station_name }}
-        </nuxt-link>
+      <template v-slot:row="row">
+        <td>{{ row.item.name }}</td>
+        <td>{{ row.item.model }}</td>
+        <td>{{ row.item.start_date }}</td>
+        <td>{{ row.item.end_date }}</td>
+        <td>{{ row.item.data_class }}</td>
+        <td>{{ row.item.dataset }}</td>
+        <td>
+          <nuxt-link
+            :to="'/data/station/' + row.item.station_id"
+            v-text="row.item.station_name"
+          />
+        </td>
+        <td>
+          <a :href="row.item.waf_url" target="_blank">TODO</a>
+        </td>
       </template>
-      <template v-slot:item.waf_url="instrument">
-        <a :href="instrument.item.waf_url" target="_blank">
-          TODO
-        </a>
-      </template>
-    </v-data-table>
+    </selectable-table>
   </v-layout>
 </template>
 
 <script>
 import axios from '~/plugins/axios'
+import { unpackageInstrument } from '~/plugins/unpackage'
+
 import mapInstructions from '~/components/MapInstructions'
 import tableInstructions from '~/components/TableInstructions'
+import SelectableMap from '~/components/SelectableMap'
+import SelectableTable from '~/components/SelectableTable'
 
 export default {
   components: {
     'map-instructions': mapInstructions,
+    'selectable-map': SelectableMap,
+    'selectable-table': SelectableTable,
     'table-instructions': tableInstructions
   },
   async asyncData({ params }) {
@@ -41,14 +79,14 @@ export default {
     const instrumentsResponse = await axios.get(instrumentsURL + '?' + queryParams)
 
     return {
-      instruments: instrumentsResponse.data.features.map((instrument) => {
-        return instrument.properties
-      })
+      instruments: instrumentsResponse.data.features.map(unpackageInstrument)
     }
   },
   data() {
     return {
-      instruments: []
+      boundingBox: null,
+      instruments: [],
+      selectedInstrument: null
     }
   },
   computed: {
@@ -70,6 +108,16 @@ export default {
           value: key
         }
       })
+    },
+    visibleInstruments() {
+      if (this.boundingBox === null) {
+        return this.instruments
+      } else {
+        return this.instrument.filter((instrument) => {
+          const coords = this.$L.latLng(instrument.geometry.coordinates)
+          return this.boundingBox.contains(coords)
+        })
+      }
     }
   },
   nuxtI18n: {

--- a/plugins/unpackage.js
+++ b/plugins/unpackage.js
@@ -1,0 +1,67 @@
+
+function standardizedCountryName(geoJSON) {
+  return {
+    en: geoJSON.properties.country_name_en,
+    fr: geoJSON.properties.country_name_fr
+  }
+}
+
+function standardizedGeometry(geoJSON) {
+  return {
+    type: geoJSON.geometry.type,
+    coordinates: [
+      geoJSON.geometry.coordinates[1],
+      geoJSON.geometry.coordinates[0]
+    ]
+  }
+}
+
+function unpackageStation(geoJSON) {
+  const station = geoJSON.properties
+  station.identifier = station.woudc_id
+
+  station.country_name = standardizedCountryName(geoJSON)
+  station.geometry = standardizedGeometry(geoJSON)
+  station.last_validated_datetime =
+    station.last_validated_datetime.substring(0, 10)
+
+  return station
+}
+
+function unpackageInstrument(geoJSON) {
+  const instrument = geoJSON.properties
+
+  instrument.country_name = standardizedCountryName(geoJSON)
+  instrument.geometry = standardizedGeometry(geoJSON)
+
+  return instrument
+}
+
+function unpackageContributor(geoJSON) {
+  const contributor = geoJSON.properties
+
+  contributor.country_name = standardizedCountryName(geoJSON)
+  contributor.geometry = standardizedGeometry(geoJSON)
+
+  return contributor
+}
+
+function unpackageDeployment(geoJSON) {
+  const deployment = geoJSON.properties
+
+  deployment.country_name = standardizedCountryName(geoJSON)
+
+  return deployment
+}
+
+function unpackageDefault(geoJSON) {
+  return geoJSON.properties
+}
+
+export {
+  unpackageStation,
+  unpackageContributor,
+  unpackageInstrument,
+  unpackageDeployment,
+  unpackageDefault
+}

--- a/store/wmoRegions.js
+++ b/store/wmoRegions.js
@@ -1,0 +1,68 @@
+
+import axios from 'axios'
+
+
+const state = () => ({
+  regions: {},
+  loaded: false
+})
+
+const getters = {
+  all(state) {
+    return state.regions
+  },
+  africa(state) {
+    return state.loaded ? state.regions.I : null
+  },
+  asia(state) {
+    return state.loaded ? state.regions.II : null
+  },
+  europe(state) {
+    return state.loaded ? state.regions.VI : null
+  },
+  northAmerica(state) {
+    return state.loaded ? state.regions.IV : null
+  },
+  southAmerica(state) {
+    return state.loaded ? state.regions.III : null
+  },
+  southWestPacific(state) {
+    return state.loaded ? state.regions.V : null
+  }
+}
+
+const mutations = {
+  setBoundaryPoints(state, regions) {
+    state.regions = regions
+  },
+  setLoaded(state, loaded) {
+    state.loaded = loaded
+  }
+}
+
+const actions = {
+  async download({ commit, state }, proc) {
+    if (state.loaded) {
+      return false
+    }
+
+    const response = await axios.get(process.env.WMO_REGIONS_URL)
+    const regionShapes = {}
+
+    for (const region of response.data.features) {
+      const regionID = region.properties.roman_num
+      regionShapes[regionID] = region
+    }
+
+    commit('setBoundaryPoints', regionShapes)
+    commit('setLoaded', true)
+  }
+}
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations
+}


### PR DESCRIPTION
Creates interactive map components displaying markers on certain points of interest around the globe. Selecting markers on the map causes the corresponding row in the tables below to be selected, and vice versa.

The maps are generally similar to the old WOUDC UI in appearance and function.

Maps (and the tables they interact with) have been put on the list pages (stations, contributors, and instruments). There are more pages that will eventually have maps, such as the search page, products pages, and dataset info pages; each of these will have a dedicated pull request that adds maps along with other features.