### PR TITLE
Replace v-layout Containers

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -54,11 +54,9 @@
         Français
       </nuxt-link>
     </v-app-bar>
-    <v-content>
-      <v-container>
-        <nuxt />
-      </v-container>
-    </v-content>
+    <v-main>
+      <nuxt />
+    </v-main>
     <v-footer app>
       <span>&copy; 2020</span>
       <v-spacer />

--- a/pages/about/dataaccess.vue
+++ b/pages/about/dataaccess.vue
@@ -1,6 +1,10 @@
 <template>
-  <div>
-    <h1>{{ $t('about.access.title') }}</h1>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('about.access.title') }}</h1>
+      </v-col>
+    </v-row>
     <v-row>
       <v-col cols="8">
         <p>{{ $t('about.access.blurb.body-intro') }}</p>
@@ -82,252 +86,256 @@
         </v-card>
       </v-col>
     </v-row>
-    <div id="data-search-section">
-      <h2>{{ $t('about.access.search.title') }}</h2>
-      <i18n path="about.access.search.blurb.body-intro" tag="p">
-        <template v-slot:search>
-          <nuxt-link :to="localePath('data-explore')">
-            {{ $t('common.search') }}
-          </nuxt-link>
-        </template>
-      </i18n>
-      <i18n path="about.access.search.blurb.body-howto" tag="p">
-        <template v-slot:how-to>
-          <a :href="searchHelpURL" target="_blank">
-            {{ $t('about.access.search.how-to') }}
-          </a>
-        </template>
-      </i18n>
-      <v-card class="mt-1 mb-4" color="info">
-        <v-card-text>
-          {{ $t('about.access.search.note') }}
-        </v-card-text>
-      </v-card>
-    </div>
-    <div id="waf-section">
-      <h2>{{ $t('about.access.waf.title') }}</h2>
-      <i18n path="about.access.waf.blurb.body-intro" tag="p">
-        <template v-slot:waf>
-          <a :href="wafURL" target="_blank">
-            {{ $t('common.wafFull') }}
-          </a>
-        </template>
-      </i18n>
-      <i18n path="about.access.waf.blurb.body-files" tag="p">
-        <template v-slot:summary>
-          <a :href="wafSummaryURL" target="_blank">
-            {{ $t('about.access.waf.summary') }}
-          </a>
-        </template>
-      </i18n>
-      <i18n path="about.access.waf.blurb.body-howto" tag="p">
-        <template v-slot:how-to>
-          <a :href="wafGuideURL" target="_blank">
-            {{ $t('about.access.waf.how-to') }}
-          </a>
-        </template>
-      </i18n>
-    </div>
-    <div id="web-services-section">
-      <h2>{{ $t('about.access.web.title') }}</h2>
-      <p>{{ $t('about.access.web.blurb.body-intro') }}</p>
-      <i18n path="about.access.web.blurb.body-standards" tag="p">
-        <template v-slot:ogc>
-          <a :href="ogcURL" target="_blank">
-            {{ $t('common.ogc') }}
-          </a>
-        </template>
-        <template v-slot:iso>
-          <a :href="isoURL" target="_blank">
-            {{ $t('common.iso') }}
-          </a>
-        </template>
-        <template v-slot:interoperability>
-          <a :href="interoperabilityURL" target="_blank">
-            {{ $t('common.interoperability') }}
-          </a>
-        </template>
-        <template v-slot:wis>
-          <a :href="wisURL" target="_blank">
-            {{ $t('common.wis') }}
-          </a>
-        </template>
-      </i18n>
-      <v-card class="mt-1 mb-4" color="info">
-        <v-card-title class="pt-3 pb-0">
-          {{ $t('about.access.web.table.title') }}
-        </v-card-title>
-        <v-card-text>
-          <span>That font size is too big. Also the colour is wrong.</span>
-        </v-card-text>
-      </v-card>
-      <div id="csw-subsection">
-        <h3>{{ $t('about.access.csw.title') }}</h3>
-        <i18n class="mb-0" path="about.access.csw.blurb" tag="p">
-          <template v-slot:ogc-cs>
-            <a :href="ogcStandardsURL" target="_blank">
-              {{ $t('common.ogc-cs') }}
-            </a>
-          </template>
-        </i18n>
-        <v-card class="mt-1 mb-4" color="info">
-          <v-card-title class="pt-3 pb-0">
-            {{ $t('about.access.csw.note.title') }}
-          </v-card-title>
-          <v-card-text>
-            <i18n class="mb-0" path="about.access.csw.note.body" tag="p">
-              <template v-slot:link>
-                <a :href="cswURL" target="_blank">
-                  {{ cswURL }}
-                </a>
-              </template>
-            </i18n>
-          </v-card-text>
-        </v-card>
-      </div>
-      <div id="wms-subsection">
-        <h3>{{ $t('about.access.wms.title') }}</h3>
-        <i18n path="about.access.wms.blurb" tag="p">
-          <template v-slot:wms>
-            <a href="" target="_blank">
-              {{ $t('common.wms') }}
-            </a>
-          </template>
-        </i18n>
-        <v-card class="mt-1 mb-4" color="info">
-          <v-card-title class="pt-3 pb-0">
-            {{ $t('about.access.wms.note.title') }}
-          </v-card-title>
-          <v-card-text>
-            <i18n class="mb-0" path="about.access.wms.note.body" tag="p">
-              <template v-slot:link>
-                <a :href="wmsURL" target="_blank">
-                  {{ wmsURL }}
-                </a>
-              </template>
-            </i18n>
-          </v-card-text>
-        </v-card>
-      </div>
-      <div id="wfs-subsection">
-        <h3>{{ $t('about.access.wfs.title') }}</h3>
-        <i18n path="about.access.wfs.blurb.body-intro" tag="p">
-          <template v-slot:wfs>
-            <a href="" target="_blank">
-              {{ $t('common.wfs') }}
-            </a>
-          </template>
-        </i18n>
-        <p>{{ $t('about.access.wfs.blurb.body-limits') }}</p>
-        <v-card class="mt-1 mb-4" color="info">
-          <v-card-title class="pt-3 pb-0">
-            {{ $t('about.access.wfs.note.title') }}
-          </v-card-title>
-          <v-card-text>
-            <i18n class="mb-0" path="about.access.wfs.note.body" tag="p">
-              <template v-slot:link>
-                <a :href="wfsURL" target="_blank">
-                  {{ wfsURL }}
-                </a>
-              </template>
-            </i18n>
-          </v-card-text>
-        </v-card>
-      </div>
-      <div id="wps-section">
-        <h3>{{ $t('about.access.wps.title') }}</h3>
-        <i18n path="about.access.wps.blurb" tag="p">
-          <template v-slot:wps>
-            <a href="" target="_blank">
-              {{ $t('common.wps') }}
-            </a>
-          </template>
-        </i18n>
-        <v-card class="mt-1 mb-4" color="info">
-          <v-card-title class="pt-3 pb-0">
-            {{ $t('about.access.wps.note.title') }}
-          </v-card-title>
-          <v-card-text>
-            <i18n class="mb-0" path="about.access.wps.note.body" tag="p">
-              <template v-slot:link>
-                <a :href="wpsURL" target="_blank">
-                  {{ wpsURL }}
-                </a>
-              </template>
-            </i18n>
-          </v-card-text>
-        </v-card>
-      </div>
-    </div>
-    <div id="definitions-service-section">
-      <h2>{{ $t('about.access.definitions.title') }}</h2>
-      <p>{{ $t('about.access.definitions.blurb') }}</p>
-      <v-card class="mt-1 mb-4" color="info">
-        <v-card-title class="pt-3 pb-0">
-          {{ $t('about.access.definitions.note.title') }}
-        </v-card-title>
-        <v-card-text>
-          <i18n class="mb-0" path="about.access.definitions.note.body" tag="p">
-            <template v-slot:link>
-              <a :href="definitionsURL" target="_blank">
-                {{ definitionsURL }}
+    <v-row>
+      <v-col>
+        <div id="data-search-section">
+          <h2>{{ $t('about.access.search.title') }}</h2>
+          <i18n path="about.access.search.blurb.body-intro" tag="p">
+            <template v-slot:search>
+              <nuxt-link :to="localePath('data-explore')">
+                {{ $t('common.search') }}
+              </nuxt-link>
+            </template>
+          </i18n>
+          <i18n path="about.access.search.blurb.body-howto" tag="p">
+            <template v-slot:how-to>
+              <a :href="searchHelpURL" target="_blank">
+                {{ $t('about.access.search.how-to') }}
               </a>
             </template>
           </i18n>
-        </v-card-text>
-      </v-card>
-    </div>
-    <div id="iso-catalogue-section">
-      <h2>{{ $t('about.access.iso.title') }}</h2>
-      <p>{{ $t('about.access.iso.blurb-intro') }}</p>
-      <v-card class="mt-1 mb-4" color="info">
-        <v-card-title class="pt-3 pb-0">
-          {{ $t('about.access.iso.note.title') }}
-        </v-card-title>
-        <v-card-text>
-          <i18n class="mb-0" path="about.access.iso.note.body" tag="p">
-            <template v-slot:link>
+          <v-card class="mt-1 mb-4" color="info">
+            <v-card-text>
+              {{ $t('about.access.search.note') }}
+            </v-card-text>
+          </v-card>
+        </div>
+        <div id="waf-section">
+          <h2>{{ $t('about.access.waf.title') }}</h2>
+          <i18n path="about.access.waf.blurb.body-intro" tag="p">
+            <template v-slot:waf>
+              <a :href="wafURL" target="_blank">
+                {{ $t('common.wafFull') }}
+              </a>
+            </template>
+          </i18n>
+          <i18n path="about.access.waf.blurb.body-files" tag="p">
+            <template v-slot:summary>
+              <a :href="wafSummaryURL" target="_blank">
+                {{ $t('about.access.waf.summary') }}
+              </a>
+            </template>
+          </i18n>
+          <i18n path="about.access.waf.blurb.body-howto" tag="p">
+            <template v-slot:how-to>
+              <a :href="wafGuideURL" target="_blank">
+                {{ $t('about.access.waf.how-to') }}
+              </a>
+            </template>
+          </i18n>
+        </div>
+        <div id="web-services-section">
+          <h2>{{ $t('about.access.web.title') }}</h2>
+          <p>{{ $t('about.access.web.blurb.body-intro') }}</p>
+          <i18n path="about.access.web.blurb.body-standards" tag="p">
+            <template v-slot:ogc>
+              <a :href="ogcURL" target="_blank">
+                {{ $t('common.ogc') }}
+              </a>
+            </template>
+            <template v-slot:iso>
               <a :href="isoURL" target="_blank">
-                {{ isoURL }}
+                {{ $t('common.iso') }}
+              </a>
+            </template>
+            <template v-slot:interoperability>
+              <a :href="interoperabilityURL" target="_blank">
+                {{ $t('common.interoperability') }}
+              </a>
+            </template>
+            <template v-slot:wis>
+              <a :href="wisURL" target="_blank">
+                {{ $t('common.wis') }}
               </a>
             </template>
           </i18n>
-        </v-card-text>
-      </v-card>
-      <i18n path="about.access.iso.blurb-howto" tag="p">
-        <template v-slot:how-to>
-          <a href="" target="_blank">
-            {{ $t('about.access.iso.how-to') }}
-          </a>
-        </template>
-      </i18n>
-    </div>
-    <div id="examples-section">
-      <h2>{{ $t('about.access.examples.title') }}</h2>
-      <i18n path="about.access.examples.blurb" tag="p">
-        <template v-slot:github>
-          <a :href="githubURL" target="_blank">
-            {{ $t('common.github') }}
-          </a>
-        </template>
-      </i18n>
-      <v-card>
-        <v-list id="example-list" dense>
-          <v-list-item>
-            <a :href="examples.pywoudc" target="_blank">
-              pywoudc
-            </a> : {{ $t('about.access.examples.links.pywoudc') }}
-          </v-list-item>
-          <v-divider />
-          <v-list-item>
-            <a :href="examples.notebooks" target="_blank">
-              notebooks
-            </a> : {{ $t('about.access.examples.links.notebooks') }}
-          </v-list-item>
-        </v-list>
-      </v-card>
-    </div>
-  </div>
+          <v-card class="mt-1 mb-4" color="info">
+            <v-card-title class="pt-3 pb-0">
+              {{ $t('about.access.web.table.title') }}
+            </v-card-title>
+            <v-card-text>
+              <span>That font size is too big. Also the colour is wrong.</span>
+            </v-card-text>
+          </v-card>
+          <div id="csw-subsection">
+            <h3>{{ $t('about.access.csw.title') }}</h3>
+            <i18n class="mb-0" path="about.access.csw.blurb" tag="p">
+              <template v-slot:ogc-cs>
+                <a :href="ogcStandardsURL" target="_blank">
+                  {{ $t('common.ogc-cs') }}
+                </a>
+              </template>
+            </i18n>
+            <v-card class="mt-1 mb-4" color="info">
+              <v-card-title class="pt-3 pb-0">
+                {{ $t('about.access.csw.note.title') }}
+              </v-card-title>
+              <v-card-text>
+                <i18n class="mb-0" path="about.access.csw.note.body" tag="p">
+                  <template v-slot:link>
+                    <a :href="cswURL" target="_blank">
+                      {{ cswURL }}
+                    </a>
+                  </template>
+                </i18n>
+              </v-card-text>
+            </v-card>
+          </div>
+          <div id="wms-subsection">
+            <h3>{{ $t('about.access.wms.title') }}</h3>
+            <i18n path="about.access.wms.blurb" tag="p">
+              <template v-slot:wms>
+                <a href="" target="_blank">
+                  {{ $t('common.wms') }}
+                </a>
+              </template>
+            </i18n>
+            <v-card class="mt-1 mb-4" color="info">
+              <v-card-title class="pt-3 pb-0">
+                {{ $t('about.access.wms.note.title') }}
+              </v-card-title>
+              <v-card-text>
+                <i18n class="mb-0" path="about.access.wms.note.body" tag="p">
+                  <template v-slot:link>
+                    <a :href="wmsURL" target="_blank">
+                      {{ wmsURL }}
+                    </a>
+                  </template>
+                </i18n>
+              </v-card-text>
+            </v-card>
+          </div>
+          <div id="wfs-subsection">
+            <h3>{{ $t('about.access.wfs.title') }}</h3>
+            <i18n path="about.access.wfs.blurb.body-intro" tag="p">
+              <template v-slot:wfs>
+                <a href="" target="_blank">
+                  {{ $t('common.wfs') }}
+                </a>
+              </template>
+            </i18n>
+            <p>{{ $t('about.access.wfs.blurb.body-limits') }}</p>
+            <v-card class="mt-1 mb-4" color="info">
+              <v-card-title class="pt-3 pb-0">
+                {{ $t('about.access.wfs.note.title') }}
+              </v-card-title>
+              <v-card-text>
+                <i18n class="mb-0" path="about.access.wfs.note.body" tag="p">
+                  <template v-slot:link>
+                    <a :href="wfsURL" target="_blank">
+                      {{ wfsURL }}
+                    </a>
+                  </template>
+                </i18n>
+              </v-card-text>
+            </v-card>
+          </div>
+          <div id="wps-section">
+            <h3>{{ $t('about.access.wps.title') }}</h3>
+            <i18n path="about.access.wps.blurb" tag="p">
+              <template v-slot:wps>
+                <a href="" target="_blank">
+                  {{ $t('common.wps') }}
+                </a>
+              </template>
+            </i18n>
+            <v-card class="mt-1 mb-4" color="info">
+              <v-card-title class="pt-3 pb-0">
+                {{ $t('about.access.wps.note.title') }}
+              </v-card-title>
+              <v-card-text>
+                <i18n class="mb-0" path="about.access.wps.note.body" tag="p">
+                  <template v-slot:link>
+                    <a :href="wpsURL" target="_blank">
+                      {{ wpsURL }}
+                    </a>
+                  </template>
+                </i18n>
+              </v-card-text>
+            </v-card>
+          </div>
+        </div>
+        <div id="definitions-service-section">
+          <h2>{{ $t('about.access.definitions.title') }}</h2>
+          <p>{{ $t('about.access.definitions.blurb') }}</p>
+          <v-card class="mt-1 mb-4" color="info">
+            <v-card-title class="pt-3 pb-0">
+              {{ $t('about.access.definitions.note.title') }}
+            </v-card-title>
+            <v-card-text>
+              <i18n class="mb-0" path="about.access.definitions.note.body" tag="p">
+                <template v-slot:link>
+                  <a :href="definitionsURL" target="_blank">
+                    {{ definitionsURL }}
+                  </a>
+                </template>
+              </i18n>
+            </v-card-text>
+          </v-card>
+        </div>
+        <div id="iso-catalogue-section">
+          <h2>{{ $t('about.access.iso.title') }}</h2>
+          <p>{{ $t('about.access.iso.blurb-intro') }}</p>
+          <v-card class="mt-1 mb-4" color="info">
+            <v-card-title class="pt-3 pb-0">
+              {{ $t('about.access.iso.note.title') }}
+            </v-card-title>
+            <v-card-text>
+              <i18n class="mb-0" path="about.access.iso.note.body" tag="p">
+                <template v-slot:link>
+                  <a :href="isoURL" target="_blank">
+                    {{ isoURL }}
+                  </a>
+                </template>
+              </i18n>
+            </v-card-text>
+          </v-card>
+          <i18n path="about.access.iso.blurb-howto" tag="p">
+            <template v-slot:how-to>
+              <a href="" target="_blank">
+                {{ $t('about.access.iso.how-to') }}
+              </a>
+            </template>
+          </i18n>
+        </div>
+        <div id="examples-section">
+          <h2>{{ $t('about.access.examples.title') }}</h2>
+          <i18n path="about.access.examples.blurb" tag="p">
+            <template v-slot:github>
+              <a :href="githubURL" target="_blank">
+                {{ $t('common.github') }}
+              </a>
+            </template>
+          </i18n>
+          <v-card>
+            <v-list id="example-list" dense>
+              <v-list-item>
+                <a :href="examples.pywoudc" target="_blank">
+                  pywoudc
+                </a> : {{ $t('about.access.examples.links.pywoudc') }}
+              </v-list-item>
+              <v-divider />
+              <v-list-item>
+                <a :href="examples.notebooks" target="_blank">
+                  notebooks
+                </a> : {{ $t('about.access.examples.links.notebooks') }}
+              </v-list-item>
+            </v-list>
+          </v-card>
+        </div>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/about/datapolicy.vue
+++ b/pages/about/datapolicy.vue
@@ -1,109 +1,113 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('about.policy.title') }}</h1>
-    <i18n path="about.policy.blurb" tag="p">
-      <template v-slot:wmo-policy>
-        <a :href="wmoURL" target="_blank">
-          {{ $t('about.policy.wmo-policy') }}
-        </a>
-      </template>
-      <template v-slot:gaw-policy>
-        <a :href="gawURL" target="_blank">
-          {{ $t('about.policy.gaw-policy') }}
-        </a>
-      </template>
-    </i18n>
-    <h2>{{ $t('about.policy.wmo.title') }}</h2>
-    <p>{{ $t('about.policy.wmo.blurb.body-intro') }}</p>
-    <i18n path="about.policy.wmo.blurb.body-resolution40" tag="p">
-      <template v-slot:link>
-        <a :href="resolution40" target="_blank">
-          {{ $t('about.policy.wmo.link') }}
-        </a>
-      </template>
-    </i18n>
-    <h2>{{ $t('about.policy.gaw.title') }}</h2>
-    <p>{{ $t('about.policy.gaw.blurb') }}</p>
-    <v-card class="mt-1 mb-4" color="info">
-      <v-card-title class="pt-3 pb-0">
-        {{ $t('about.policy.gaw.note.title') }}
-      </v-card-title>
-      <v-card-text>
-        {{ $t('about.policy.gaw.note.body') }}
-      </v-card-text>
-    </v-card>
-    <h2>{{ $t('about.policy.doi.title') }}</h2>
-    <i18n path="about.policy.doi.blurb" tag="p">
-      <template v-slot:dois>
-        <a :href="doisURL" target="_blank">
-          {{ $t('about.policy.doi.dois') }}
-        </a>
-      </template>
-    </i18n>
-    <v-card>
-      <v-card-title class="card">
-        {{ $t('about.policy.doi.note1.title') }}
-      </v-card-title>
-      <v-card-text>
-        <ul>
-          <li v-for="dataClass in classOrder" :key="dataClass">
-            {{ $t('about.policy.doi.note1.items.' + dataClass) }}
-          </li>
-        </ul>
-      </v-card-text>
-    </v-card>
-    <v-card>
-      <v-card-title class="card">
-        {{ $t('about.policy.doi.note2.title') }}
-      </v-card-title>
-      <v-card-text>
-        <ul>
-          <li v-for="dataset in datasetOrder" :key="dataset">
-            {{ $t('about.policy.doi.note2.items.' + dataset) }}
-          </li>
-        </ul>
-      </v-card-text>
-    </v-card>
-    <h2>{{ $t('about.policy.publishing.title') }}</h2>
-    <p>{{ $t('about.policy.publishing.blurb-citations') }}</p>
-    <v-card>
-      <v-card-title class="card">
-        {{ $t('about.policy.publishing.note1.title') }}
-      </v-card-title>
-      <v-card-text>
-        {{ $t('about.policy.publishing.note1.body') }}
-      </v-card-text>
-    </v-card>
-    <v-card>
-      <v-card-title class="card">
-        {{ $t('about.policy.publishing.note2.title') }}
-      </v-card-title>
-      <v-card-text>
-        <ol>
-          <li v-for="dataClass in classOrder" :key="dataClass">
-            {{ $t('about.policy.publishing.note2.items.' + dataClass) }}
-          </li>
-        </ol>
-      </v-card-text>
-    </v-card>
-    <i18n path="about.policy.publishing.blurb-contributors" tag="p">
-      <template v-slot:contributors-page>
-        <nuxt-link :to="localePath('contributors')">
-          {{ $t('common.contributors-page') }}
-        </nuxt-link>
-      </template>
-    </i18n>
-    <h2>{{ $t('about.policy.products.title') }}</h2>
-    <p>{{ $t('about.policy.products.blurb') }}</p>
-    <v-card>
-      <v-card-title class="card">
-        {{ $t('about.policy.products.note.title') }}
-      </v-card-title>
-      <v-card-text>
-        {{ $t('about.policy.products.note.body') }}
-      </v-card-text>
-    </v-card>
-  </v-layout>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('about.policy.title') }}</h1>
+        <i18n path="about.policy.blurb" tag="p">
+          <template v-slot:wmo-policy>
+            <a :href="wmoURL" target="_blank">
+              {{ $t('about.policy.wmo-policy') }}
+            </a>
+          </template>
+          <template v-slot:gaw-policy>
+            <a :href="gawURL" target="_blank">
+              {{ $t('about.policy.gaw-policy') }}
+            </a>
+          </template>
+        </i18n>
+        <h2>{{ $t('about.policy.wmo.title') }}</h2>
+        <p>{{ $t('about.policy.wmo.blurb.body-intro') }}</p>
+        <i18n path="about.policy.wmo.blurb.body-resolution40" tag="p">
+          <template v-slot:link>
+            <a :href="resolution40" target="_blank">
+              {{ $t('about.policy.wmo.link') }}
+            </a>
+          </template>
+        </i18n>
+        <h2>{{ $t('about.policy.gaw.title') }}</h2>
+        <p>{{ $t('about.policy.gaw.blurb') }}</p>
+        <v-card class="mt-1 mb-4" color="info">
+          <v-card-title class="pt-3 pb-0">
+            {{ $t('about.policy.gaw.note.title') }}
+          </v-card-title>
+          <v-card-text>
+            {{ $t('about.policy.gaw.note.body') }}
+          </v-card-text>
+        </v-card>
+        <h2>{{ $t('about.policy.doi.title') }}</h2>
+        <i18n path="about.policy.doi.blurb" tag="p">
+          <template v-slot:dois>
+            <a :href="doisURL" target="_blank">
+              {{ $t('about.policy.doi.dois') }}
+            </a>
+          </template>
+        </i18n>
+        <v-card>
+          <v-card-title class="card">
+            {{ $t('about.policy.doi.note1.title') }}
+          </v-card-title>
+          <v-card-text>
+            <ul>
+              <li v-for="dataClass in classOrder" :key="dataClass">
+                {{ $t('about.policy.doi.note1.items.' + dataClass) }}
+              </li>
+            </ul>
+          </v-card-text>
+        </v-card>
+        <v-card>
+          <v-card-title class="card">
+            {{ $t('about.policy.doi.note2.title') }}
+          </v-card-title>
+          <v-card-text>
+            <ul>
+              <li v-for="dataset in datasetOrder" :key="dataset">
+                {{ $t('about.policy.doi.note2.items.' + dataset) }}
+              </li>
+            </ul>
+          </v-card-text>
+        </v-card>
+        <h2>{{ $t('about.policy.publishing.title') }}</h2>
+        <p>{{ $t('about.policy.publishing.blurb-citations') }}</p>
+        <v-card>
+          <v-card-title class="card">
+            {{ $t('about.policy.publishing.note1.title') }}
+          </v-card-title>
+          <v-card-text>
+            {{ $t('about.policy.publishing.note1.body') }}
+          </v-card-text>
+        </v-card>
+        <v-card>
+          <v-card-title class="card">
+            {{ $t('about.policy.publishing.note2.title') }}
+          </v-card-title>
+          <v-card-text>
+            <ol>
+              <li v-for="dataClass in classOrder" :key="dataClass">
+                {{ $t('about.policy.publishing.note2.items.' + dataClass) }}
+              </li>
+            </ol>
+          </v-card-text>
+        </v-card>
+        <i18n path="about.policy.publishing.blurb-contributors" tag="p">
+          <template v-slot:contributors-page>
+            <nuxt-link :to="localePath('contributors')">
+              {{ $t('common.contributors-page') }}
+            </nuxt-link>
+          </template>
+        </i18n>
+        <h2>{{ $t('about.policy.products.title') }}</h2>
+        <p>{{ $t('about.policy.products.blurb') }}</p>
+        <v-card>
+          <v-card-title class="card">
+            {{ $t('about.policy.products.note.title') }}
+          </v-card-title>
+          <v-card-text>
+            {{ $t('about.policy.products.note.body') }}
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/about/dataquality.vue
+++ b/pages/about/dataquality.vue
@@ -1,58 +1,62 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('about.quality.title') }}</h1>
-    <p>{{ $t('about.quality.blurb') }}</p>
-    <h2>{{ $t('common.gawFull') }}</h2>
-    <i18n path="about.quality.gaw-blurb" tag="p">
-      <template v-slot:gaw-qa>
-        <a :href="gawURL" target="_blank">
-          {{ $t('about.quality.gaw-qa') }}
-        </a>
-      </template>
-    </i18n>
-    <h2>{{ $t('about.quality.sag.title') }}</h2>
-    <i18n path="about.quality.sag.blurb.body-intro" tag="p">
-      <template v-slot:sop>
-        <nuxt-link :to="localePath('resources-sop')">
-          {{ $t('common.sop') }}
-        </nuxt-link>
-      </template>
-    </i18n>
-    <p>{{ $t('about.quality.sag.blurb.body-standards') }}</p>
-    <ul>
-      <li v-for="link in sagLinks" :key="link.to">
-        <a :href="link.to">
-          {{ link.text }}
-        </a> ({{ link.note }})
-      </li>
-    </ul>
-    <h2>{{ $t('about.quality.eccc.title') }}</h2>
-    <p>{{ $t('about.quality.eccc.blurb') }}</p>
-    <ul>
-      <li>
-        <i18n path="about.quality.eccc.item1" tag="span">
-          <template v-slot:guidelines>
-            <nuxt-link :to="localePath('about-formats')">
-              {{ $t('common.guidelines') }}
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('about.quality.title') }}</h1>
+        <p>{{ $t('about.quality.blurb') }}</p>
+        <h2>{{ $t('common.gawFull') }}</h2>
+        <i18n path="about.quality.gaw-blurb" tag="p">
+          <template v-slot:gaw-qa>
+            <a :href="gawURL" target="_blank">
+              {{ $t('about.quality.gaw-qa') }}
+            </a>
+          </template>
+        </i18n>
+        <h2>{{ $t('about.quality.sag.title') }}</h2>
+        <i18n path="about.quality.sag.blurb.body-intro" tag="p">
+          <template v-slot:sop>
+            <nuxt-link :to="localePath('resources-sop')">
+              {{ $t('common.sop') }}
             </nuxt-link>
           </template>
         </i18n>
-      </li>
-      <li>{{ $t('about.quality.eccc.item2') }}</li>
-      <li>{{ $t('about.quality.eccc.item3') }}</li>
-      <li>{{ $t('about.quality.eccc.item4') }}</li>
-      <li>{{ $t('about.quality.eccc.item5') }}</li>
-      <li>
-        <i18n path="about.quality.eccc.item6" tag="span">
-          <template v-slot:access>
-            <nuxt-link :to="localePath('about-dataaccess')">
-              {{ $t('common.access') }}
-            </nuxt-link>
-          </template>
-        </i18n>
-      </li>
-    </ul>
-  </v-layout>
+        <p>{{ $t('about.quality.sag.blurb.body-standards') }}</p>
+        <ul>
+          <li v-for="link in sagLinks" :key="link.to">
+            <a :href="link.to">
+              {{ link.text }}
+            </a> ({{ link.note }})
+          </li>
+        </ul>
+        <h2>{{ $t('about.quality.eccc.title') }}</h2>
+        <p>{{ $t('about.quality.eccc.blurb') }}</p>
+        <ul>
+          <li>
+            <i18n path="about.quality.eccc.item1" tag="span">
+              <template v-slot:guidelines>
+                <nuxt-link :to="localePath('about-formats')">
+                  {{ $t('common.guidelines') }}
+                </nuxt-link>
+              </template>
+            </i18n>
+          </li>
+          <li>{{ $t('about.quality.eccc.item2') }}</li>
+          <li>{{ $t('about.quality.eccc.item3') }}</li>
+          <li>{{ $t('about.quality.eccc.item4') }}</li>
+          <li>{{ $t('about.quality.eccc.item5') }}</li>
+          <li>
+            <i18n path="about.quality.eccc.item6" tag="span">
+              <template v-slot:access>
+                <nuxt-link :to="localePath('about-dataaccess')">
+                  {{ $t('common.access') }}
+                </nuxt-link>
+              </template>
+            </i18n>
+          </li>
+        </ul>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/about/faq.vue
+++ b/pages/about/faq.vue
@@ -1,63 +1,67 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('about.faq.title') }}</h1>
-    <p>{{ $t('about.faq.blurb') }}</p>
-    <div v-for="(question, index) in $t('about.faq.questions')" :key="index">
-      <h4>{{ question.text }}</h4>
-      <i18n :path="'about.faq.questions[' + index + '].answer'" tag="p">
-        <template v-slot:policy>
-          <nuxt-link :to="localePath('about-datapolicy')">
-            {{ $t('common.policy') }}
-          </nuxt-link>
-        </template>
-        <template v-slot:submission>
-          <nuxt-link :to="localePath('contributors-submission')">
-            {{ $t('common.submission') }}
-          </nuxt-link>
-        </template>
-        <template v-slot:registration-form>
-          <nuxt-link :to="localePath('contributors-registration')">
-            {{ $t('common.registration-form') }}
-          </nuxt-link>
-        </template>
-        <template v-slot:access>
-          <nuxt-link :to="localePath('about-dataaccess')">
-            {{ $t('common.access') }}
-          </nuxt-link>
-        </template>
-        <template v-slot:search>
-          <nuxt-link :to="localePath('data-explore')">
-            {{ $t('common.search') }}
-          </nuxt-link>
-        </template>
-        <template v-slot:products>
-          <nuxt-link :to="localePath('data-products')">
-            {{ $t('common.products') }}
-          </nuxt-link>
-        </template>
-        <template v-slot:contributors-page>
-          <nuxt-link :to="localePath('contributors')">
-            {{ $t('common.contributors-page') }}
-          </nuxt-link>
-        </template>
-        <template v-slot:accessibility>
-          <a :href="accessibilityURL" target="_blank">
-            {{ $t('common.accessibility') }}
-          </a>
-        </template>
-        <template v-slot:usability>
-          <a :href="usabilityURL" target="_blank">
-            {{ $t('about.faq.usability') }}
-          </a>
-        </template>
-        <template v-slot:w3c>
-          <a :href="w3cURL" target="_blank">
-            {{ $t('common.w3c') }}
-          </a>
-        </template>
-      </i18n>
-    </div>
-  </v-layout>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('about.faq.title') }}</h1>
+        <p>{{ $t('about.faq.blurb') }}</p>
+        <div v-for="(question, index) in $t('about.faq.questions')" :key="index">
+          <h4>{{ question.text }}</h4>
+          <i18n :path="'about.faq.questions[' + index + '].answer'" tag="p">
+            <template v-slot:policy>
+              <nuxt-link :to="localePath('about-datapolicy')">
+                {{ $t('common.policy') }}
+              </nuxt-link>
+            </template>
+            <template v-slot:submission>
+              <nuxt-link :to="localePath('contributors-submission')">
+                {{ $t('common.submission') }}
+              </nuxt-link>
+            </template>
+            <template v-slot:registration-form>
+              <nuxt-link :to="localePath('contributors-registration')">
+                {{ $t('common.registration-form') }}
+              </nuxt-link>
+            </template>
+            <template v-slot:access>
+              <nuxt-link :to="localePath('about-dataaccess')">
+                {{ $t('common.access') }}
+              </nuxt-link>
+            </template>
+            <template v-slot:search>
+              <nuxt-link :to="localePath('data-explore')">
+                {{ $t('common.search') }}
+              </nuxt-link>
+            </template>
+            <template v-slot:products>
+              <nuxt-link :to="localePath('data-products')">
+                {{ $t('common.products') }}
+              </nuxt-link>
+            </template>
+            <template v-slot:contributors-page>
+              <nuxt-link :to="localePath('contributors')">
+                {{ $t('common.contributors-page') }}
+              </nuxt-link>
+            </template>
+            <template v-slot:accessibility>
+              <a :href="accessibilityURL" target="_blank">
+                {{ $t('common.accessibility') }}
+              </a>
+            </template>
+            <template v-slot:usability>
+              <a :href="usabilityURL" target="_blank">
+                {{ $t('about.faq.usability') }}
+              </a>
+            </template>
+            <template v-slot:w3c>
+              <a :href="w3cURL" target="_blank">
+                {{ $t('common.w3c') }}
+              </a>
+            </template>
+          </i18n>
+        </div>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/about/formats.vue
+++ b/pages/about/formats.vue
@@ -1,53 +1,57 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('about.formats.title') }}</h1>
-    <i18n path="about.formats.blurb.body-intro" tag="p">
-      <template v-slot:extended>
-        <strong>{{ $t('common.extended') }}</strong>
-      </template>
-    </i18n>
-    <i18n path="about.formats.blurb.body-extcsv" tag="p">
-      <template v-slot:extended>
-        <strong>{{ $t('common.extended') }}</strong>
-      </template>
-      <template v-slot:access>
-        <nuxt-link :to="localePath('about-dataaccess')">
-          {{ $t('common.access') }}
-        </nuxt-link>
-      </template>
-    </i18n>
-    <v-card class="mt-1 mb-4" color="info">
-      <v-card-text>
-        {{ $t('about.formats.note') }}
-      </v-card-text>
-    </v-card>
-    <h2> {{ $t('about.formats.contributor-guide.title') }}</h2>
-    <ul>
-      <li>
-        <a :href="contributorsURL" target="_blank">
-          {{ $t('about.formats.contributor-guide.link') }}
-        </a>
-      </li>
-    </ul>
-    <h2>{{ $t('about.formats.examples.title') }}</h2>
-    <p>{{ $t('about.formats.examples.blurb') }}</p>
-    <h3>{{ $t('about.formats.examples.ozone') }}</h3>
-    <ul>
-      <li v-for="(link, i) in prepareLinks(ozoneDatasets)" :key="i">
-        <a :href="link.url" target="_blank">
-          {{ link.text }}
-        </a>
-      </li>
-    </ul>
-    <h3>{{ $t('about.formats.examples.uv') }}</h3>
-    <ul>
-      <li v-for="(link, index) in prepareLinks(uvDatasets)" :key="index">
-        <a :href="link.url" target="_blank">
-          {{ link.text }}
-        </a>
-      </li>
-    </ul>
-  </v-layout>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('about.formats.title') }}</h1>
+        <i18n path="about.formats.blurb.body-intro" tag="p">
+          <template v-slot:extended>
+            <strong>{{ $t('common.extended') }}</strong>
+          </template>
+        </i18n>
+        <i18n path="about.formats.blurb.body-extcsv" tag="p">
+          <template v-slot:extended>
+            <strong>{{ $t('common.extended') }}</strong>
+          </template>
+          <template v-slot:access>
+            <nuxt-link :to="localePath('about-dataaccess')">
+              {{ $t('common.access') }}
+            </nuxt-link>
+          </template>
+        </i18n>
+        <v-card class="mt-1 mb-4" color="info">
+          <v-card-text>
+            {{ $t('about.formats.note') }}
+          </v-card-text>
+        </v-card>
+        <h2> {{ $t('about.formats.contributor-guide.title') }}</h2>
+        <ul>
+          <li>
+            <a :href="contributorsURL" target="_blank">
+              {{ $t('about.formats.contributor-guide.link') }}
+            </a>
+          </li>
+        </ul>
+        <h2>{{ $t('about.formats.examples.title') }}</h2>
+        <p>{{ $t('about.formats.examples.blurb') }}</p>
+        <h3>{{ $t('about.formats.examples.ozone') }}</h3>
+        <ul>
+          <li v-for="(link, i) in prepareLinks(ozoneDatasets)" :key="i">
+            <a :href="link.url" target="_blank">
+              {{ link.text }}
+            </a>
+          </li>
+        </ul>
+        <h3>{{ $t('about.formats.examples.uv') }}</h3>
+        <ul>
+          <li v-for="(link, index) in prepareLinks(uvDatasets)" :key="index">
+            <a :href="link.url" target="_blank">
+              {{ link.text }}
+            </a>
+          </li>
+        </ul>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/about/glossary.vue
+++ b/pages/about/glossary.vue
@@ -1,33 +1,37 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('about.glossary.title') }}</h1>
-    <p>{{ $t('about.glossary.blurb') }}</p>
-    <div v-for="(item, index) in $t('about.glossary.terms')" :key="index">
-      <h4>{{ item.term }}</h4>
-      <i18n :path="'about.glossary.terms[' + index + '].definition'" tag="p">
-        <template v-slot:carcinogenesis>
-          <a :href="carcinogensURL" target="_blank">
-            {{ $t('about.glossary.carcinogenesis') }}
-          </a>
-        </template>
-        <template v-slot:registration-page>
-          <nuxt-link :to="localePath('contributors-registration')">
-            {{ $t('common.registration-page') }}
-          </nuxt-link>
-        </template>
-        <template v-slot:w3>
-          <a :href="w3URL" target="_blank">
-            www.w3.org
-          </a>
-        </template>
-        <template v-slot:waf>
-          <a :href="wafURL" target="_blank">
-            {{ wafURL }}
-          </a>
-        </template>
-      </i18n>
-    </div>
-  </v-layout>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('about.glossary.title') }}</h1>
+        <p>{{ $t('about.glossary.blurb') }}</p>
+        <div v-for="(item, index) in $t('about.glossary.terms')" :key="index">
+          <h4>{{ item.term }}</h4>
+          <i18n :path="'about.glossary.terms[' + index + '].definition'" tag="p">
+            <template v-slot:carcinogenesis>
+              <a :href="carcinogensURL" target="_blank">
+                {{ $t('about.glossary.carcinogenesis') }}
+              </a>
+            </template>
+            <template v-slot:registration-page>
+              <nuxt-link :to="localePath('contributors-registration')">
+                {{ $t('common.registration-page') }}
+              </nuxt-link>
+            </template>
+            <template v-slot:w3>
+              <a :href="w3URL" target="_blank">
+                www.w3.org
+              </a>
+            </template>
+            <template v-slot:waf>
+              <a :href="wafURL" target="_blank">
+                {{ wafURL }}
+              </a>
+            </template>
+          </i18n>
+        </div>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -1,55 +1,59 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h2>{{ $t('about.home.title') }}</h2>
-    <p>{{ $t('about.home.blurb.body-intro') }}</p>
-    <p>{{ $t('about.home.blurb.body-datasets') }}</p>
-    <i18n path="about.home.blurb.body-contributors" tag="p">
-      <template v-slot:stations>
-        <nuxt-link :to="localePath('data-stations')">
-          {{ $t('common.stations') }}
-        </nuxt-link>
-      </template>
-      <template v-slot:contributors>
-        <nuxt-link :to="localePath('contributors')">
-          {{ $t('common.contributors') }}
-        </nuxt-link>
-      </template>
-    </i18n>
-    <p>{{ $t('about.home.blurb.body-products') }}</p>
-    <i18n path="about.home.blurb.body-access" tag="p">
-      <template v-slot:search>
-        <nuxt-link :to="localePath('data-explore')">
-          {{ $t('common.search') }}
-        </nuxt-link>
-      </template>
-      <template v-slot:access>
-        <nuxt-link :to="localePath('about-dataaccess')">
-          {{ $t('common.access') }}
-        </nuxt-link>
-      </template>
-    </i18n>
-    <v-card
-      id="history"
-      itemprop="hasPart"
-      itemscope
-      itemtype="http://schema.org/CreativeWork"
-    >
-      <v-card-title itemprop="name">
-        {{ $t('about.home.history.title') }}
-      </v-card-title>
-      <v-list itemprop="about" itemscope itemtype="http://schema.org/ItemList">
-        <v-list-item
-          v-for="(event, year, i) in $t('about.home.history.milestones')"
-          :key="i"
-          itemprop="itemListElement"
+  <v-container>
+    <v-row>
+      <v-col>
+        <h2>{{ $t('about.home.title') }}</h2>
+        <p>{{ $t('about.home.blurb.body-intro') }}</p>
+        <p>{{ $t('about.home.blurb.body-datasets') }}</p>
+        <i18n path="about.home.blurb.body-contributors" tag="p">
+          <template v-slot:stations>
+            <nuxt-link :to="localePath('data-stations')">
+              {{ $t('common.stations') }}
+            </nuxt-link>
+          </template>
+          <template v-slot:contributors>
+            <nuxt-link :to="localePath('contributors')">
+              {{ $t('common.contributors') }}
+            </nuxt-link>
+          </template>
+        </i18n>
+        <p>{{ $t('about.home.blurb.body-products') }}</p>
+        <i18n path="about.home.blurb.body-access" tag="p">
+          <template v-slot:search>
+            <nuxt-link :to="localePath('data-explore')">
+              {{ $t('common.search') }}
+            </nuxt-link>
+          </template>
+          <template v-slot:access>
+            <nuxt-link :to="localePath('about-dataaccess')">
+              {{ $t('common.access') }}
+            </nuxt-link>
+          </template>
+        </i18n>
+        <v-card
+          id="history"
+          itemprop="hasPart"
+          itemscope
+          itemtype="http://schema.org/CreativeWork"
         >
-          <span>
-            <strong>{{ year }}</strong> : {{ event }}
-          </span>
-        </v-list-item>
-      </v-list>
-    </v-card>
-  </v-layout>
+          <v-card-title itemprop="name">
+            {{ $t('about.home.history.title') }}
+          </v-card-title>
+          <v-list itemprop="about" itemscope itemtype="http://schema.org/ItemList">
+            <v-list-item
+              v-for="(event, year, i) in $t('about.home.history.milestones')"
+              :key="i"
+              itemprop="itemListElement"
+            >
+              <span>
+                <strong>{{ year }}</strong> : {{ event }}
+              </span>
+            </v-list-item>
+          </v-list>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/about/standards.vue
+++ b/pages/about/standards.vue
@@ -1,48 +1,52 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('about.standards.title') }}</h1>
-    <i18n path="about.standards.blurb-intro" tag="p">
-      <template v-slot:interoperability>
-        <a :href="interoperabilityURL" target="_blank">
-          {{ $t('common.interoperability') }}
-        </a>
-      </template>
-      <template v-slot:wis>
-        <a :href="wisURL" target="_blank">
-          {{ $t('common.wis') }}
-        </a>
-      </template>
-    </i18n>
-    <v-data-table
-      id="standards-table"
-      :headers="headers"
-      :items="rows"
-      hide-default-footer
-      class="elevation-1"
-    >
-      <template v-slot:item.formats="props">
-        <v-chip v-for="link in props.item.formats" :key="link.to" class="resource" label>
-          <a :href="link.to" target="_blank">
-            {{ link.text }}
-          </a>
-        </v-chip>
-      </template>
-      <template v-slot:item.services="props">
-        <v-chip v-for="link in props.item.services" :key="link.to" class="resource" label>
-          <a :href="link.to" target="_blank">
-            {{ link.text }}
-          </a>
-        </v-chip>
-      </template>
-    </v-data-table>
-    <i18n path="about.standards.blurb-howto" tag="p">
-      <template v-slot:access>
-        <nuxt-link :to="localePath('about-dataaccess')">
-          {{ $t('common.access') }}
-        </nuxt-link>
-      </template>
-    </i18n>
-  </v-layout>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('about.standards.title') }}</h1>
+        <i18n path="about.standards.blurb-intro" tag="p">
+          <template v-slot:interoperability>
+            <a :href="interoperabilityURL" target="_blank">
+              {{ $t('common.interoperability') }}
+            </a>
+          </template>
+          <template v-slot:wis>
+            <a :href="wisURL" target="_blank">
+              {{ $t('common.wis') }}
+            </a>
+          </template>
+        </i18n>
+        <v-data-table
+          id="standards-table"
+          :headers="headers"
+          :items="rows"
+          hide-default-footer
+          class="elevation-1"
+        >
+          <template v-slot:item.formats="props">
+            <v-chip v-for="link in props.item.formats" :key="link.to" class="resource" label>
+              <a :href="link.to" target="_blank">
+                {{ link.text }}
+              </a>
+            </v-chip>
+          </template>
+          <template v-slot:item.services="props">
+            <v-chip v-for="link in props.item.services" :key="link.to" class="resource" label>
+              <a :href="link.to" target="_blank">
+                {{ link.text }}
+              </a>
+            </v-chip>
+          </template>
+        </v-data-table>
+        <i18n path="about.standards.blurb-howto" tag="p">
+          <template v-slot:access>
+            <nuxt-link :to="localePath('about-dataaccess')">
+              {{ $t('common.access') }}
+            </nuxt-link>
+          </template>
+        </i18n>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -1,74 +1,78 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('contact.title') }}</h1>
-    <i18n path="contact.blurb.body-faq" tag="p">
-      <template v-slot:faq>
-        <nuxt-link :to="localePath('about-faq')">
-          {{ $t('common.faq') }}
-        </nuxt-link>
-      </template>
-    </i18n>
-    <i18n path="contact.blurb.body-contact" tag="p">
-      <template v-slot:woudc>
-        <strong>{{ $t('common.woudc') }}</strong>
-      </template>
-    </i18n>
-    <i18n path="contact.blurb.body-alternatives" tag="p">
-      <template v-slot:contact-channels>
-        <nuxt-link to="#other-contacts">
-          {{ $t('contact.contact-channels') }}
-        </nuxt-link>
-      </template>
-    </i18n>
-    <hr>
-    <span class="headline">{{ $t('contact.contact-info') }}</span>
-    <p>{{ $t('contact.prompt') }}</p>
-    <h4>
-      <span class="red--text">*</span>
-      {{ $t('contact.name') }} <span class="red--text">({{ $t('contact.required') }})</span>
-    </h4>
-    <v-text-field v-model="selectedName" :label="$t('contact.name')" solo />
-    <h4>
-      <span class="red--text">*</span>
-      {{ $t('contact.email') }} <span class="red--text">({{ $t('contact.required') }})</span>
-    </h4>
-    <v-text-field v-model="selectedEmail" :label="$t('contact.email')" solo />
-    <v-card class="mt-1 mb-4" color="info">
-      <v-card-title class="pt-3 pb-0">
-        {{ $t('contact.note.title') }}
-      </v-card-title>
-      <v-card-text>
-        <i18n path="contact.note.body" tag="span">
-          <template v-slot:privacy-act>
-            <i><a href="privacyActURL" target="_blank">
-              {{ $t('common.privacy-act') }}
-            </a></i>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('contact.title') }}</h1>
+        <i18n path="contact.blurb.body-faq" tag="p">
+          <template v-slot:faq>
+            <nuxt-link :to="localePath('about-faq')">
+              {{ $t('common.faq') }}
+            </nuxt-link>
           </template>
         </i18n>
-      </v-card-text>
-    </v-card>
-    <h4>
-      <span class="red--text">*</span>
-      {{ $t('contact.subject') }}
-      <span class="red--text">({{ $t('contact.required') }})</span>
-    </h4>
-    <v-text-field v-model="selectedSubject" :label="$t('contact.subject')" solo />
-    <h4>
-      <span class="red--text">*</span>
-      {{ $t('contact.message') }}
-      <span class="red--text">({{ $t('contact.required') }})</span>
-    </h4>
-    <v-textarea v-model="selectedMessage" :label="$t('contact.message')" solo />
-    <div id="other-contacts">
-      <h2>{{ $t('contact.other-channels') }}</h2>
-      <div v-for="(lines, header) in $t('contact.contact-methods')" :key="header">
-        <h4>{{ header }}:</h4>
-        <div v-for="(line, index) in lines" :key="index">
-          {{ line }}
+        <i18n path="contact.blurb.body-contact" tag="p">
+          <template v-slot:woudc>
+            <strong>{{ $t('common.woudc') }}</strong>
+          </template>
+        </i18n>
+        <i18n path="contact.blurb.body-alternatives" tag="p">
+          <template v-slot:contact-channels>
+            <nuxt-link to="#other-contacts">
+              {{ $t('contact.contact-channels') }}
+            </nuxt-link>
+          </template>
+        </i18n>
+        <hr>
+        <span class="headline">{{ $t('contact.contact-info') }}</span>
+        <p>{{ $t('contact.prompt') }}</p>
+        <h4>
+          <span class="red--text">*</span>
+          {{ $t('contact.name') }} <span class="red--text">({{ $t('contact.required') }})</span>
+        </h4>
+        <v-text-field v-model="selectedName" :label="$t('contact.name')" solo />
+        <h4>
+          <span class="red--text">*</span>
+          {{ $t('contact.email') }} <span class="red--text">({{ $t('contact.required') }})</span>
+        </h4>
+        <v-text-field v-model="selectedEmail" :label="$t('contact.email')" solo />
+        <v-card class="mt-1 mb-4" color="info">
+          <v-card-title class="pt-3 pb-0">
+            {{ $t('contact.note.title') }}
+          </v-card-title>
+          <v-card-text>
+            <i18n path="contact.note.body" tag="span">
+              <template v-slot:privacy-act>
+                <i><a href="privacyActURL" target="_blank">
+                  {{ $t('common.privacy-act') }}
+                </a></i>
+              </template>
+            </i18n>
+          </v-card-text>
+        </v-card>
+        <h4>
+          <span class="red--text">*</span>
+          {{ $t('contact.subject') }}
+          <span class="red--text">({{ $t('contact.required') }})</span>
+        </h4>
+        <v-text-field v-model="selectedSubject" :label="$t('contact.subject')" solo />
+        <h4>
+          <span class="red--text">*</span>
+          {{ $t('contact.message') }}
+          <span class="red--text">({{ $t('contact.required') }})</span>
+        </h4>
+        <v-textarea v-model="selectedMessage" :label="$t('contact.message')" solo />
+        <div id="other-contacts">
+          <h2>{{ $t('contact.other-channels') }}</h2>
+          <div v-for="(lines, header) in $t('contact.contact-methods')" :key="header">
+            <h4>{{ header }}:</h4>
+            <div v-for="(line, index) in lines" :key="index">
+              {{ line }}
+            </div>
+          </div>
         </div>
-      </div>
-    </div>
-  </v-layout>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/contributors/_id.vue
+++ b/pages/contributors/_id.vue
@@ -1,10 +1,14 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('contributors.list.title') }}</h1>
-    <h2 v-if="contributors.length > 0">
-      {{ contributors[0].acronym + ' - ' + contributors[0].name }}
-    </h2>
-    <p>{{ $t('contributors.list.blurb') }}</p>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('contributors.list.title') }}</h1>
+        <h2 v-if="contributors.length > 0">
+          {{ contributors[0].acronym + ' - ' + contributors[0].name }}
+        </h2>
+        <p>{{ $t('contributors.list.blurb') }}</p>
+      </v-col>
+    </v-row>
     <v-row>
       <v-col>
         <selectable-map
@@ -28,48 +32,52 @@
         <table-instructions id="table-instructions" />
       </v-col>
     </v-row>
-    <v-data-table
-      :headers="contributorHeaders"
-      :items="contributors"
-      hide-default-footer
-      class="elevation-1"
-    >
-      <template v-slot:item.acronym="contributor">
-        <nuxt-link :to="'/contributors/' + contributor.item.acronym">
-          {{ contributor.item.acronym }}
-        </nuxt-link>
-      </template>
-      <template v-slot:item.name="contributor">
-        <a :href="contributor.item.url">
-          {{ contributor.item.name }}
-        </a>
-      </template>
-      <template v-slot:item.country="contributor">
-        {{ contributor.item.country_name[$i18n.locale] }}
-      </template>
-    </v-data-table>
-    <v-data-table
-      id="deployments-table"
-      :headers="deploymentHeaders"
-      :items="deployments"
-      class="elevation-1"
-    >
-      <template v-slot:item="deployment">
-        <tr>
-          <td>
-            <nuxt-link :to="'/data/stations/' + deployment.item.station_id">
-              {{ deployment.item.station_id }}
+    <v-row>
+      <v-col>
+        <v-data-table
+          :headers="contributorHeaders"
+          :items="contributors"
+          hide-default-footer
+          class="elevation-1"
+        >
+          <template v-slot:item.acronym="contributor">
+            <nuxt-link :to="'/contributors/' + contributor.item.acronym">
+              {{ contributor.item.acronym }}
             </nuxt-link>
-          </td>
-          <td>{{ deployment.item.station_name }}</td>
-          <td>{{ deployment.item.station_type }}</td>
-          <td>{{ deployment.item.country_name[$i18n.locale] }}</td>
-          <td>{{ deployment.item.start_date }}</td>
-          <td>{{ deployment.item.end_date }}</td>
-        </tr>
-      </template>
-    </v-data-table>
-  </v-layout>
+          </template>
+          <template v-slot:item.name="contributor">
+            <a :href="contributor.item.url">
+              {{ contributor.item.name }}
+            </a>
+          </template>
+          <template v-slot:item.country="contributor">
+            {{ contributor.item.country_name[$i18n.locale] }}
+          </template>
+        </v-data-table>
+        <v-data-table
+          id="deployments-table"
+          :headers="deploymentHeaders"
+          :items="deployments"
+          class="elevation-1"
+        >
+          <template v-slot:item="deployment">
+            <tr>
+              <td>
+                <nuxt-link :to="'/data/stations/' + deployment.item.station_id">
+                  {{ deployment.item.station_id }}
+                </nuxt-link>
+              </td>
+              <td>{{ deployment.item.station_name }}</td>
+              <td>{{ deployment.item.station_type }}</td>
+              <td>{{ deployment.item.country_name[$i18n.locale] }}</td>
+              <td>{{ deployment.item.start_date }}</td>
+              <td>{{ deployment.item.end_date }}</td>
+            </tr>
+          </template>
+        </v-data-table>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/contributors/index.vue
+++ b/pages/contributors/index.vue
@@ -1,7 +1,11 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('contributors.list.title') }}</h1>
-    <p>{{ $t('contributors.list.blurb') }}</p>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('contributors.list.title') }}</h1>
+        <p>{{ $t('contributors.list.blurb') }}</p>
+      </v-col>
+    </v-row>
     <v-row>
       <v-col>
         <selectable-map
@@ -26,31 +30,35 @@
         <table-instructions id="table-instructions" />
       </v-col>
     </v-row>
-    <selectable-table
-      :elements="visibleContributors"
-      :headers="headers"
-      :selected="selectedContributor"
-      @select="selectedContributor = $event"
-    >
-      <template v-slot:row="row">
-        <td>
-          <nuxt-link :to="'/contributors/' + row.item.acronym">
-            {{ row.item.acronym }}
-          </nuxt-link>
-        </td>
-        <td>{{ row.item.project }}</td>
-        <td>
-          <a :href="row.item.url" target="_blank">
-            {{ row.item.name }}
-          </a>
-        </td>
-        <td>{{ row.item.country_name[$i18n.locale] }}</td>
-        <td>{{ row.item.start_date }}</td>
-        <td>{{ row.item.end_date }}</td>
-        <td>{{ row.item.wmo_region_id }}</td>
-      </template>
-    </selectable-table>
-  </v-layout>
+    <v-row>
+      <v-col>
+        <selectable-table
+          :elements="visibleContributors"
+          :headers="headers"
+          :selected="selectedContributor"
+          @select="selectedContributor = $event"
+        >
+          <template v-slot:row="row">
+            <td>
+              <nuxt-link :to="'/contributors/' + row.item.acronym">
+                {{ row.item.acronym }}
+              </nuxt-link>
+            </td>
+            <td>{{ row.item.project }}</td>
+            <td>
+              <a :href="row.item.url" target="_blank">
+                {{ row.item.name }}
+              </a>
+            </td>
+            <td>{{ row.item.country_name[$i18n.locale] }}</td>
+            <td>{{ row.item.start_date }}</td>
+            <td>{{ row.item.end_date }}</td>
+            <td>{{ row.item.wmo_region_id }}</td>
+          </template>
+        </selectable-table>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/contributors/registration.vue
+++ b/pages/contributors/registration.vue
@@ -1,56 +1,60 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('contributors.registration.title') }}</h1>
-    <p>{{ $t('contributors.registration.blurb.body-accounts') }}</p>
-    <i18n path="contributors.registration.blurb.body-submissions" tag="p">
-      <template v-slot:submissions>
-        <nuxt-link :to="localePath('contributors-submission')">
-          {{ $tc('common.submission', 2) }}
-        </nuxt-link>
-      </template>
-    </i18n>
-    <ol>
-      <li>
-        <i18n path="contributors.registration.step1" tag="span">
-          <template v-slot:policy>
-            <nuxt-link :to="localePath('about-datapolicy')">
-              {{ $t('common.policy') }}
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('contributors.registration.title') }}</h1>
+        <p>{{ $t('contributors.registration.blurb.body-accounts') }}</p>
+        <i18n path="contributors.registration.blurb.body-submissions" tag="p">
+          <template v-slot:submissions>
+            <nuxt-link :to="localePath('contributors-submission')">
+              {{ $tc('common.submission', 2) }}
             </nuxt-link>
           </template>
         </i18n>
-      </li>
-      <li>
-        <i18n path="contributors.registration.step2" tag="span">
-          <template v-slot:wmo-gaw>
-            <a :href="gawHomeURL" target="_blank">
-              {{ $t('contributors.registration.wmo-gaw') }}
-            </a>
-          </template>
-          <template v-slot:more>
-            <a :href="wmoGAWUrl" target="_blank">
-              {{ $t('contributors.registration.more') }}
-            </a>
-          </template>
-        </i18n>
-      </li>
-      <li>
-        <i18n path="contributors.registration.step3" tag="span">
-          <template v-slot:contacting>
-            <nuxt-link :to="localePath('contact')">
-              {{ $t('contributors.registration.contacting') }}
-            </nuxt-link>
-          </template>
-          <template v-slot:register>
-            <strong>{{ $t('contributors.registration.register') }}</strong>
-          </template>
-        </i18n>
-      </li>
-      <li>
-        {{ $t('contributors.registration.step4') }}
-      </li>
-    </ol>
-    <p>{{ $t('contributors.registration.thanks') }}</p>
-  </v-layout>
+        <ol>
+          <li>
+            <i18n path="contributors.registration.step1" tag="span">
+              <template v-slot:policy>
+                <nuxt-link :to="localePath('about-datapolicy')">
+                  {{ $t('common.policy') }}
+                </nuxt-link>
+              </template>
+            </i18n>
+          </li>
+          <li>
+            <i18n path="contributors.registration.step2" tag="span">
+              <template v-slot:wmo-gaw>
+                <a :href="gawHomeURL" target="_blank">
+                  {{ $t('contributors.registration.wmo-gaw') }}
+                </a>
+              </template>
+              <template v-slot:more>
+                <a :href="wmoGAWUrl" target="_blank">
+                  {{ $t('contributors.registration.more') }}
+                </a>
+              </template>
+            </i18n>
+          </li>
+          <li>
+            <i18n path="contributors.registration.step3" tag="span">
+              <template v-slot:contacting>
+                <nuxt-link :to="localePath('contact')">
+                  {{ $t('contributors.registration.contacting') }}
+                </nuxt-link>
+              </template>
+              <template v-slot:register>
+                <strong>{{ $t('contributors.registration.register') }}</strong>
+              </template>
+            </i18n>
+          </li>
+          <li>
+            {{ $t('contributors.registration.step4') }}
+          </li>
+        </ol>
+        <p>{{ $t('contributors.registration.thanks') }}</p>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/contributors/submission.vue
+++ b/pages/contributors/submission.vue
@@ -1,51 +1,55 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('contributors.submission.title') }}</h1>
-    <p>{{ $t('contributors.submission.blurb-intro') }}</p>
-    <v-card class="mt-1 mb-4" color="info">
-      <v-card-text>
-        <strong>{{ $t('common.note') }} (1)</strong>
-        {{ $t('contributors.submission.note1') }}
-      </v-card-text>
-    </v-card>
-    <h2>{{ $t('contributors.submission.subtitle') }}</h2>
-    <ol>
-      <li>
-        <i18n path="contributors.submission.step1" tag="span">
-          <template v-slot:formats>
-            <nuxt-link :to="localePath('about-formats')">
-              {{ $t('common.formats') }}
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('contributors.submission.title') }}</h1>
+        <p>{{ $t('contributors.submission.blurb-intro') }}</p>
+        <v-card class="mt-1 mb-4" color="info">
+          <v-card-text>
+            <strong>{{ $t('common.note') }} (1)</strong>
+            {{ $t('contributors.submission.note1') }}
+          </v-card-text>
+        </v-card>
+        <h2>{{ $t('contributors.submission.subtitle') }}</h2>
+        <ol>
+          <li>
+            <i18n path="contributors.submission.step1" tag="span">
+              <template v-slot:formats>
+                <nuxt-link :to="localePath('about-formats')">
+                  {{ $t('common.formats') }}
+                </nuxt-link>
+              </template>
+            </i18n>
+          </li>
+          <li>
+            <i18n path="contributors.submission.step2" tag="span">
+              <template v-slot:ftp>
+                <a :href="ftpPath" target="_blank">
+                  {{ $t('common.ftp') }}
+                </a>
+              </template>
+            </i18n>
+          </li>
+          <li>{{ $t('contributors.submission.step3') }}</li>
+          <li>{{ $t('contributors.submission.step4') }}</li>
+          <li>{{ $t('contributors.submission.step5') }}</li>
+        </ol>
+        <v-card class="mt-1 mb-4" color="info">
+          <v-card-text>
+            <strong>{{ $t('common.note') }} (2)</strong>
+            {{ $t('contributors.submission.note2') }}
+          </v-card-text>
+        </v-card>
+        <i18n path="contributors.submission.blurb-contact" tag="p">
+          <template v-slot:contact-us>
+            <nuxt-link :to="localePath('contact')">
+              {{ $t('common.contact-us') }}
             </nuxt-link>
           </template>
         </i18n>
-      </li>
-      <li>
-        <i18n path="contributors.submission.step2" tag="span">
-          <template v-slot:ftp>
-            <a :href="ftpPath" target="_blank">
-              {{ $t('common.ftp') }}
-            </a>
-          </template>
-        </i18n>
-      </li>
-      <li>{{ $t('contributors.submission.step3') }}</li>
-      <li>{{ $t('contributors.submission.step4') }}</li>
-      <li>{{ $t('contributors.submission.step5') }}</li>
-    </ol>
-    <v-card class="mt-1 mb-4" color="info">
-      <v-card-text>
-        <strong>{{ $t('common.note') }} (2)</strong>
-        {{ $t('contributors.submission.note2') }}
-      </v-card-text>
-    </v-card>
-    <i18n path="contributors.submission.blurb-contact" tag="p">
-      <template v-slot:contact-us>
-        <nuxt-link :to="localePath('contact')">
-          {{ $t('common.contact-us') }}
-        </nuxt-link>
-      </template>
-    </i18n>
-  </v-layout>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/contributors/validation.vue
+++ b/pages/contributors/validation.vue
@@ -1,8 +1,12 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('contributors.validation.title') }}</h1>
-    <p>{{ $t('contributors.validation.blurb') }}</p>
-  </v-layout>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('contributors.validation.title') }}</h1>
+        <p>{{ $t('contributors.validation.blurb') }}</p>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/data/explore.vue
+++ b/pages/data/explore.vue
@@ -1,69 +1,73 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('data.explore.title') }}</h1>
-    <p>{{ $t('data.explore.blurb.body-datasets') }}</p>
-    <p>{{ $t('data.explore.blurb.body-search') }}</p>
-    <i18n path="data.explore.blurb.body-howto" tag="p">
-      <template v-slot:how-to>
-        <nuxt-link :to="localePath('about-dataaccess')">
-          {{ $t('data.explore.how-to') }}
-        </nuxt-link>
-      </template>
-    </i18n>
-    <h3>{{ $t('data.explore.dataset.title') }}</h3>
-    <v-select
-      class="woudc-select"
-      :value="selectedDataset"
-      :items="datasetOptions"
-      :label="$t('data.explore.dataset.placeholder')"
-      item-text="name"
-      item-value="value"
-      solo
-      @input="clearAll()"
-    />
-    <h3>{{ $t('data.explore.country.title') }}</h3>
-    <v-autocomplete
-      :value="selectedCountry"
-      :items="countries"
-      :label="$t('data.explore.country.placeholder')"
-      :item-text="countryText"
-      item-value="country_code"
-      solo
-      @input="clearStationAndInstrument()"
-    />
-    <h3>{{ $t('data.explore.station.title') }}</h3>
-    <v-autocomplete
-      :value="selectedStation"
-      :items="stations"
-      :label="$t('data.explore.station.placeholder')"
-      :item-text="stationText"
-      item-value="woudc_id"
-      solo
-      @input="clearInstrument()"
-    />
-    <h3>{{ $t('data.explore.instrument.title') }}</h3>
-    <v-select
-      :value="selectedInstrument"
-      :items="instruments"
-      :label="$t('data.explore.instrument.placeholder')"
-      :item-text="instrumentText"
-      item-value="name"
-      solo
-    />
-    <v-range-slider
-      v-model="selectedYearRange"
-      :min="minSelectableYear"
-      :max="maxSelectableYear"
-    />
-    <div id="start-year">
-      <h4>{{ $t('data.explore.start') }}</h4>
-      <input v-model="selectedYearRange[0]" type="text">
-    </div>
-    <div id="end-year">
-      <h4>{{ $t('data.explore.end') }}</h4>
-      <input v-model="selectedYearRange[1]" type="text">
-    </div>
-  </v-layout>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('data.explore.title') }}</h1>
+        <p>{{ $t('data.explore.blurb.body-datasets') }}</p>
+        <p>{{ $t('data.explore.blurb.body-search') }}</p>
+        <i18n path="data.explore.blurb.body-howto" tag="p">
+          <template v-slot:how-to>
+            <nuxt-link :to="localePath('about-dataaccess')">
+              {{ $t('data.explore.how-to') }}
+            </nuxt-link>
+          </template>
+        </i18n>
+        <h3>{{ $t('data.explore.dataset.title') }}</h3>
+        <v-select
+          class="woudc-select"
+          :value="selectedDataset"
+          :items="datasetOptions"
+          :label="$t('data.explore.dataset.placeholder')"
+          item-text="name"
+          item-value="value"
+          solo
+          @input="clearAll()"
+        />
+        <h3>{{ $t('data.explore.country.title') }}</h3>
+        <v-autocomplete
+          :value="selectedCountry"
+          :items="countries"
+          :label="$t('data.explore.country.placeholder')"
+          :item-text="countryText"
+          item-value="country_code"
+          solo
+          @input="clearStationAndInstrument()"
+        />
+        <h3>{{ $t('data.explore.station.title') }}</h3>
+        <v-autocomplete
+          :value="selectedStation"
+          :items="stations"
+          :label="$t('data.explore.station.placeholder')"
+          :item-text="stationText"
+          item-value="woudc_id"
+          solo
+          @input="clearInstrument()"
+        />
+        <h3>{{ $t('data.explore.instrument.title') }}</h3>
+        <v-select
+          :value="selectedInstrument"
+          :items="instruments"
+          :label="$t('data.explore.instrument.placeholder')"
+          :item-text="instrumentText"
+          item-value="name"
+          solo
+        />
+        <v-range-slider
+          v-model="selectedYearRange"
+          :min="minSelectableYear"
+          :max="maxSelectableYear"
+        />
+        <div id="start-year">
+          <h4>{{ $t('data.explore.start') }}</h4>
+          <input v-model="selectedYearRange[0]" type="text">
+        </div>
+        <div id="end-year">
+          <h4>{{ $t('data.explore.end') }}</h4>
+          <input v-model="selectedYearRange[1]" type="text">
+        </div>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/data/index.vue
+++ b/pages/data/index.vue
@@ -1,14 +1,18 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h2>{{ $t('data.title') }}</h2>
-    <ul>
-      <li v-for="path in localLinks" :key="path">
-        <nuxt-link :to="localePath('data-' + path)">
-          {{ $t('data.links.' + path) }}
-        </nuxt-link>
-      </li>
-    </ul>
-  </v-layout>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h2>{{ $t('data.title') }}</h2>
+        <ul>
+          <li v-for="path in localLinks" :key="path">
+            <nuxt-link :to="localePath('data-' + path)">
+              {{ $t('data.links.' + path) }}
+            </nuxt-link>
+          </li>
+        </ul>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/data/instruments.vue
+++ b/pages/data/instruments.vue
@@ -1,7 +1,11 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('data.instruments.title') }}</h1>
-    <p>{{ $t('data.instruments.blurb') }}</p>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('data.instruments.title') }}</h1>
+        <p>{{ $t('data.instruments.blurb') }}</p>
+      </v-col>
+    </v-row>
     <v-row>
       <v-col>
         <selectable-map
@@ -29,31 +33,35 @@
         <table-instructions id="table-instructions" />
       </v-col>
     </v-row>
-    <selectable-table
-      :headers="headers"
-      :elements="visibleInstruments"
-      :selected="selectedInstrument"
-      @select="selectedInstrument = $event"
-    >
-      <template v-slot:row="row">
-        <td>{{ row.item.name }}</td>
-        <td>{{ row.item.model }}</td>
-        <td>{{ row.item.start_date }}</td>
-        <td>{{ row.item.end_date }}</td>
-        <td>{{ row.item.data_class }}</td>
-        <td>{{ row.item.dataset }}</td>
-        <td>
-          <nuxt-link
-            :to="'/data/station/' + row.item.station_id"
-            v-text="row.item.station_name"
-          />
-        </td>
-        <td>
-          <a :href="row.item.waf_url" target="_blank">TODO</a>
-        </td>
-      </template>
-    </selectable-table>
-  </v-layout>
+    <v-row>
+      <v-col>
+        <selectable-table
+          :headers="headers"
+          :elements="visibleInstruments"
+          :selected="selectedInstrument"
+          @select="selectedInstrument = $event"
+        >
+          <template v-slot:row="row">
+            <td>{{ row.item.name }}</td>
+            <td>{{ row.item.model }}</td>
+            <td>{{ row.item.start_date }}</td>
+            <td>{{ row.item.end_date }}</td>
+            <td>{{ row.item.data_class }}</td>
+            <td>{{ row.item.dataset }}</td>
+            <td>
+              <nuxt-link
+                :to="'/data/station/' + row.item.station_id"
+                v-text="row.item.station_name"
+              />
+            </td>
+            <td>
+              <a :href="row.item.waf_url" target="_blank">TODO</a>
+            </td>
+          </template>
+        </selectable-table>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/data/products/index.vue
+++ b/pages/data/products/index.vue
@@ -1,50 +1,54 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('data.products.title') }}</h1>
-    <p>{{ $t('data.products.blurb') }}</p>
-    <div id="time-series">
-      <h2>{{ $t('data.products.time-series.title') }}</h2>
-      <p>{{ $t('data.products.time-series.blurb') }}</p>
-      <ul>
-        <li v-for="(path, key) in timeSeriesLinks" :key="key">
-          <nuxt-link :to="localePath(path)">
-            {{ $t('data.products.time-series.links.' + key) }}
-          </nuxt-link>
-        </li>
-      </ul>
-    </div>
-    <div id="related-products">
-      <h2>{{ $t('data.products.related.title') }}</h2>
-      <ul>
-        <li v-for="(url, key) in relatedLinks" :key="key">
-          <a :href="url" target="_blank">
-            {{ $t('data.products.related.links.' + key) }}
-          </a>
-        </li>
-      </ul>
-    </div>
-    <div id="ozone-maps">
-      <h2>{{ $t('data.products.maps.title') }}</h2>
-      <p>{{ $t('data.products.maps.blurb') }}</p>
-      <ul>
-        <li v-for="(url, key) in mapsLinks" :key="key">
-          <a :href="url" target="_blank">
-            {{ $t('data.products.maps.links.' + key) }}
-          </a>
-        </li>
-      </ul>
-    </div>
-    <div id="summaries">
-      <h2>{{ $t('data.products.summaries.title') }}</h2>
-      <ul>
-        <li v-for="(url, key) in summariesLinks" :key="key">
-          <a :href="url" target="_blank">
-            {{ $t('data.products.summaries.links.' + key) }}
-          </a>
-        </li>
-      </ul>
-    </div>
-  </v-layout>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('data.products.title') }}</h1>
+        <p>{{ $t('data.products.blurb') }}</p>
+        <div id="time-series">
+          <h2>{{ $t('data.products.time-series.title') }}</h2>
+          <p>{{ $t('data.products.time-series.blurb') }}</p>
+          <ul>
+            <li v-for="(path, key) in timeSeriesLinks" :key="key">
+              <nuxt-link :to="localePath(path)">
+                {{ $t('data.products.time-series.links.' + key) }}
+              </nuxt-link>
+            </li>
+          </ul>
+        </div>
+        <div id="related-products">
+          <h2>{{ $t('data.products.related.title') }}</h2>
+          <ul>
+            <li v-for="(url, key) in relatedLinks" :key="key">
+              <a :href="url" target="_blank">
+                {{ $t('data.products.related.links.' + key) }}
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div id="ozone-maps">
+          <h2>{{ $t('data.products.maps.title') }}</h2>
+          <p>{{ $t('data.products.maps.blurb') }}</p>
+          <ul>
+            <li v-for="(url, key) in mapsLinks" :key="key">
+              <a :href="url" target="_blank">
+                {{ $t('data.products.maps.links.' + key) }}
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div id="summaries">
+          <h2>{{ $t('data.products.summaries.title') }}</h2>
+          <ul>
+            <li v-for="(url, key) in summariesLinks" :key="key">
+              <a :href="url" target="_blank">
+                {{ $t('data.products.summaries.links.' + key) }}
+              </a>
+            </li>
+          </ul>
+        </div>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/data/products/ozonesonde.vue
+++ b/pages/data/products/ozonesonde.vue
@@ -1,45 +1,48 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('data.products.ozonesonde.title') }}</h1>
-    <v-spacer />
-    <h2>{{ $t('data.products.common.search') }}</h2>
-    <v-expansion-panels>
-      <v-expansion-panel>
-        <v-expansion-panel-header>
-          <strong>{{ $t('common.instructions') }}</strong>
-        </v-expansion-panel-header>
-        <v-expansion-panel-content>
-          <i18n path="data.products.ozonesonde.instructions.body-selections" tag="p">
-            <template v-slot:station>
-              <strong>{{ $t('data.products.common.station') }}</strong>
-            </template>
-            <template v-slot:years>
-              <strong>{{ $t('data.products.common.years') }}</strong>
-            </template>
-          </i18n>
-          <p>{{ $t('data.products.ozonesonde.instructions.body-searching') }}</p>
-          <ul>
-            <i18n path="data.products.ozonesonde.instructions.body-pressure" tag="li">
-              <template v-slot:pressure-plots>
-                <strong>{{ $t('data.products.ozonesonde.instructions.pressure-plots') }}</strong>
-              </template>
-            </i18n>
-            <i18n path="data.products.ozonesonde.instructions.body-temperature" tag="li">
-              <template v-slot:temperature-plots>
-                <strong>{{ $t('data.products.ozonesonde.instructions.temperature-plots') }}</strong>
-              </template>
-            </i18n>
-            <i18n path="data.products.ozonesonde.instructions.body-flights" tag="li">
-              <template v-slot:flight-plots>
-                <strong>{{ $t('data.products.ozonesonde.instructions.flight-plots') }}</strong>
-              </template>
-            </i18n>
-          </ul>
-          <br>
-          <p>{{ $t('data.products.ozonesonde.instructions.body-grouping') }}</p>
-        </v-expansion-panel-content>
-      </v-expansion-panel>
-    </v-expansion-panels>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('data.products.ozonesonde.title') }}</h1>
+        <h2>{{ $t('data.products.common.search') }}</h2>
+        <v-expansion-panels>
+          <v-expansion-panel>
+            <v-expansion-panel-header>
+              <strong>{{ $t('common.instructions') }}</strong>
+            </v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <i18n path="data.products.ozonesonde.instructions.body-selections" tag="p">
+                <template v-slot:station>
+                  <strong>{{ $t('data.products.common.station') }}</strong>
+                </template>
+                <template v-slot:years>
+                  <strong>{{ $t('data.products.common.years') }}</strong>
+                </template>
+              </i18n>
+              <p>{{ $t('data.products.ozonesonde.instructions.body-searching') }}</p>
+              <ul>
+                <i18n path="data.products.ozonesonde.instructions.body-pressure" tag="li">
+                  <template v-slot:pressure-plots>
+                    <strong>{{ $t('data.products.ozonesonde.instructions.pressure-plots') }}</strong>
+                  </template>
+                </i18n>
+                <i18n path="data.products.ozonesonde.instructions.body-temperature" tag="li">
+                  <template v-slot:temperature-plots>
+                    <strong>{{ $t('data.products.ozonesonde.instructions.temperature-plots') }}</strong>
+                  </template>
+                </i18n>
+                <i18n path="data.products.ozonesonde.instructions.body-flights" tag="li">
+                  <template v-slot:flight-plots>
+                    <strong>{{ $t('data.products.ozonesonde.instructions.flight-plots') }}</strong>
+                  </template>
+                </i18n>
+              </ul>
+              <br>
+              <p>{{ $t('data.products.ozonesonde.instructions.body-grouping') }}</p>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </v-col>
+    </v-row>
     <v-row>
       <v-col>
         <div class="requiredHead mb-2">
@@ -112,29 +115,33 @@
         </selectable-map>
       </v-col>
     </v-row>
-    <div>
-      <v-btn
-        class="btn-left"
-        color="primary"
-        :disabled="selectedStation === null"
-        @click="getGraphs"
-      >
-        {{ $t('data.products.common.submit') }}
-      </v-btn>
-      <v-btn class="btn-right" @click="reset()">
-        {{ $t('data.products.common.reset') }}
-      </v-btn>
-    </div>
-    <h2>{{ $t('data.products.common.results') }}</h2>
-    <div v-for="(graphs, year) in graphURLs" :key="year">
-      <h3>{{ $t('data.products.common.year') }}: {{ year }}</h3>
-      <graph-carousel :graphs="graphs">
-        <template v-slot:preview-caption="graph">
-          {{ imagePreviewCaption(graph.item, year) }}
-        </template>
-      </graph-carousel>
-    </div>
-  </v-layout>
+    <v-row>
+      <v-col>
+        <div>
+          <v-btn
+            class="btn-left"
+            color="primary"
+            :disabled="selectedStation === null"
+            @click="getGraphs"
+          >
+            {{ $t('data.products.common.submit') }}
+          </v-btn>
+          <v-btn class="btn-right" @click="reset()">
+            {{ $t('data.products.common.reset') }}
+          </v-btn>
+        </div>
+        <h2>{{ $t('data.products.common.results') }}</h2>
+        <div v-for="(graphs, year) in graphURLs" :key="year">
+          <h3>{{ $t('data.products.common.year') }}: {{ year }}</h3>
+          <graph-carousel :graphs="graphs">
+            <template v-slot:preview-caption="graph">
+              {{ imagePreviewCaption(graph.item, year) }}
+            </template>
+          </graph-carousel>
+        </div>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/data/products/totalozone.vue
+++ b/pages/data/products/totalozone.vue
@@ -1,10 +1,9 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('data.products.totalozone.title') }}</h1>
-    <v-spacer />
-    <h2>{{ $t('data.products.common.search') }}</h2>
+  <v-container>
     <v-row>
       <v-col>
+        <h1>{{ $t('data.products.totalozone.title') }}</h1>
+        <h2>{{ $t('data.products.common.search') }}</h2>
         <v-expansion-panels>
           <v-expansion-panel>
             <v-expansion-panel-header>
@@ -27,6 +26,10 @@
             </v-expansion-panel-content>
           </v-expansion-panel>
         </v-expansion-panels>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col>
         <div class="requiredHead mb-2">
           <h3>{{ $t('data.products.common.Station') }}</h3>
           <v-chip small label class="ml-2 mt-1" color="warning">
@@ -118,29 +121,33 @@
         </selectable-map>
       </v-col>
     </v-row>
-    <div>
-      <v-btn
-        class="btn-left"
-        color="primary"
-        :disabled="selectedStation === null"
-        @click="getGraphs()"
-      >
-        {{ $t('data.products.common.submit') }}
-      </v-btn>
-      <v-btn class="btn-right" @click="reset()">
-        {{ $t('data.products.common.reset') }}
-      </v-btn>
-    </div>
-    <h2>{{ $t('data.products.common.results') }}</h2>
-    <div v-for="(graphs, year) in graphURLs" :key="year">
-      <h3>{{ $t('data.products.common.year') }}: {{ year }}</h3>
-      <graph-carousel :graphs="graphs">
-        <template v-slot:preview-caption="graph">
-          {{ imagePreviewCaption(graph.item, year) }}
-        </template>
-      </graph-carousel>
-    </div>
-  </v-layout>
+    <v-row>
+      <v-col>
+        <div>
+          <v-btn
+            class="btn-left"
+            color="primary"
+            :disabled="selectedStation === null"
+            @click="getGraphs()"
+          >
+            {{ $t('data.products.common.submit') }}
+          </v-btn>
+          <v-btn class="btn-right" @click="reset()">
+            {{ $t('data.products.common.reset') }}
+          </v-btn>
+        </div>
+        <h2>{{ $t('data.products.common.results') }}</h2>
+        <div v-for="(graphs, year) in graphURLs" :key="year">
+          <h3>{{ $t('data.products.common.year') }}: {{ year }}</h3>
+          <graph-carousel :graphs="graphs">
+            <template v-slot:preview-caption="graph">
+              {{ imagePreviewCaption(graph.item, year) }}
+            </template>
+          </graph-carousel>
+        </div>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/data/products/uvindex.vue
+++ b/pages/data/products/uvindex.vue
@@ -1,10 +1,9 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('data.products.uv-index.title') }}</h1>
-    <v-spacer />
-    <h2>{{ $t('data.products.common.search') }}</h2>
+  <v-container>
     <v-row>
       <v-col>
+        <h1>{{ $t('data.products.uv-index.title') }}</h1>
+        <h2>{{ $t('data.products.common.search') }}</h2>
         <v-expansion-panels>
           <v-expansion-panel>
             <v-expansion-panel-header>
@@ -27,6 +26,10 @@
             </v-expansion-panel-content>
           </v-expansion-panel>
         </v-expansion-panels>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col>
         <div class="requiredHead mb-2">
           <h3>{{ $t('data.products.common.Station') }}</h3>
           <v-chip small label class="ml-2 mt-1" color="warning">
@@ -123,29 +126,33 @@
         </selectable-map>
       </v-col>
     </v-row>
-    <div>
-      <v-btn
-        class="btn-left"
-        color="primary"
-        :disabled="selectedStation === null || selectedInstrument === null"
-        @click="getGraphs()"
-      >
-        {{ $t('data.products.common.submit') }}
-      </v-btn>
-      <v-btn class="btn-right" @click="reset()">
-        {{ $t('data.products.common.reset') }}
-      </v-btn>
-    </div>
-    <h2>{{ $t('data.products.common.results') }}</h2>
-    <div v-for="(graphs, year) in graphURLs" :key="year">
-      <h3>{{ $t('data.products.common.year') }}: {{ year }}</h3>
-      <graph-carousel :graphs="graphs">
-        <template v-slot:preview-caption="graph">
-          {{ imagePreviewCaption(graph.item, year) }}
-        </template>
-      </graph-carousel>
-    </div>
-  </v-layout>
+    <v-row>
+      <v-col>
+        <div>
+          <v-btn
+            class="btn-left"
+            color="primary"
+            :disabled="selectedStation === null || selectedInstrument === null"
+            @click="getGraphs()"
+          >
+            {{ $t('data.products.common.submit') }}
+          </v-btn>
+          <v-btn class="btn-right" @click="reset()">
+            {{ $t('data.products.common.reset') }}
+          </v-btn>
+        </div>
+        <h2>{{ $t('data.products.common.results') }}</h2>
+        <div v-for="(graphs, year) in graphURLs" :key="year">
+          <h3>{{ $t('data.products.common.year') }}: {{ year }}</h3>
+          <graph-carousel :graphs="graphs">
+            <template v-slot:preview-caption="graph">
+              {{ imagePreviewCaption(graph.item, year) }}
+            </template>
+          </graph-carousel>
+        </div>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/data/stations/_id.vue
+++ b/pages/data/stations/_id.vue
@@ -1,10 +1,14 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('data.stations.title') }}</h1>
-    <h2 v-if="station !== null">
-      {{ station.name + ' - ' + station.woudc_id }}
-    </h2>
-    <p>{{ $t('data.stations.blurb') }}</p>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('data.stations.title') }}</h1>
+        <h2 v-if="station !== null">
+          {{ station.name + ' - ' + station.woudc_id }}
+        </h2>
+        <p>{{ $t('data.stations.blurb') }}</p>
+      </v-col>
+    </v-row>
     <v-row>
       <v-col>
         <selectable-map
@@ -36,69 +40,73 @@
         <table-instructions id="table-instructions" />
       </v-col>
     </v-row>
-    <v-data-table
-      v-if="station !== null"
-      :headers="stationHeaders"
-      :items="[station]"
-      hide-default-footer
-      class="elevation-1"
-    >
-      <template v-slot:item.woudc_id="stn">
-        <nuxt-link :to="'/data/stations/' + stn.item.woudc_id">
-          {{ stn.item.woudc_id }}
-        </nuxt-link>
-      </template>
-      <template v-slot:item.gaw_id="stn">
-        <span v-id="stn.item.gaw_id !== null">
-          <a :href="stn.item.gaw_url" target="_blank">
-            {{ stn.item.gaw_id }}
-          </a>
-        </span>
-      </template>
-      <template v-slot:item.country="stn">
-        {{ stn.item.country_name[$i18n.locale] }}
-      </template>
-    </v-data-table>
-    <v-data-table
-      v-if="deployments.length > 0"
-      id="deployments-table"
-      :headers="deploymentHeaders"
-      :items="deployments"
-      hide-default-footer
-      class="elevation-1"
-    >
-      <template v-slot:item="deployment">
-        <tr>
-          <td>
-            <nuxt-link :to="'/contributors/' + deployment.item.contributor">
-              {{ deployment.item.contributor }}
+    <v-row>
+      <v-col>
+        <v-data-table
+          v-if="station !== null"
+          :headers="stationHeaders"
+          :items="[station]"
+          hide-default-footer
+          class="elevation-1"
+        >
+          <template v-slot:item.woudc_id="stn">
+            <nuxt-link :to="'/data/stations/' + stn.item.woudc_id">
+              {{ stn.item.woudc_id }}
             </nuxt-link>
-          </td>
-          <td>{{ deployment.item.contributor_project }}</td>
-          <td>
-            <a :href="deployment.item.contributor_url" target="_blank">
-              {{ deployment.item.contributor_name }}
+          </template>
+          <template v-slot:item.gaw_id="stn">
+            <span v-id="stn.item.gaw_id !== null">
+              <a :href="stn.item.gaw_url" target="_blank">
+                {{ stn.item.gaw_id }}
+              </a>
+            </span>
+          </template>
+          <template v-slot:item.country="stn">
+            {{ stn.item.country_name[$i18n.locale] }}
+          </template>
+        </v-data-table>
+        <v-data-table
+          v-if="deployments.length > 0"
+          id="deployments-table"
+          :headers="deploymentHeaders"
+          :items="deployments"
+          hide-default-footer
+          class="elevation-1"
+        >
+          <template v-slot:item="deployment">
+            <tr>
+              <td>
+                <nuxt-link :to="'/contributors/' + deployment.item.contributor">
+                  {{ deployment.item.contributor }}
+                </nuxt-link>
+              </td>
+              <td>{{ deployment.item.contributor_project }}</td>
+              <td>
+                <a :href="deployment.item.contributor_url" target="_blank">
+                  {{ deployment.item.contributor_name }}
+                </a>
+              </td>
+              <td>{{ deployment.item.start_date }}</td>
+              <td>{{ deployment.item.end_date }}</td>
+            </tr>
+          </template>
+        </v-data-table>
+        <v-data-table
+          v-if="instruments.length > 0"
+          id="instruments-table"
+          :headers="instrumentHeaders"
+          :items="instruments"
+          class="elevation-1"
+        >
+          <template v-slot:item.waf_url="instrument">
+            <a :href="instrument.item.waf_url" target="_blank">
+              TODO
             </a>
-          </td>
-          <td>{{ deployment.item.start_date }}</td>
-          <td>{{ deployment.item.end_date }}</td>
-        </tr>
-      </template>
-    </v-data-table>
-    <v-data-table
-      v-if="instruments.length > 0"
-      id="instruments-table"
-      :headers="instrumentHeaders"
-      :items="instruments"
-      class="elevation-1"
-    >
-      <template v-slot:item.waf_url="instrument">
-        <a :href="instrument.item.waf_url" target="_blank">
-          TODO
-        </a>
-      </template>
-    </v-data-table>
-  </v-layout>
+          </template>
+        </v-data-table>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/data/stations/index.vue
+++ b/pages/data/stations/index.vue
@@ -1,7 +1,11 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('data.stations.title') }}</h1>
-    <p>{{ $t('data.stations.blurb') }}</p>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('data.stations.title') }}</h1>
+        <p>{{ $t('data.stations.blurb') }}</p>
+      </v-col>
+    </v-row>
     <v-row>
       <v-col>
         <selectable-map
@@ -34,35 +38,39 @@
         <table-instructions id="table-instructions" />
       </v-col>
     </v-row>
-    <selectable-table
-      :headers="headers"
-      :elements="visibleStations"
-      :selected="selectedStation"
-      @select="selectedStation = $event"
-    >
-      <template v-slot:row="row">
-        <td>
-          <nuxt-link :to="'/data/stations/' + row.item.woudc_id">
-            {{ row.item.woudc_id }}
-          </nuxt-link>
-        </td>
-        <td>
-          <span v-if="row.item.gaw_id !== null">
-            <a :href="row.item.gaw_url" target="_blank">
-              {{ row.item.gaw_id }}
-            </a>
-          </span>
-        </td>
-        <td>{{ row.item.start_date }}</td>
-        <td>{{ row.item.end_date }}</td>
-        <td>{{ row.item.name }}</td>
-        <td>{{ row.item.country_name[$i18n.locale] }}</td>
-        <td>{{ row.item.last_validated_datetime }}</td>
-        <td>{{ row.item.type }}</td>
-        <td>{{ row.item.wmo_region_id }}</td>
-      </template>
-    </selectable-table>
-  </v-layout>
+    <v-row>
+      <v-col>
+        <selectable-table
+          :headers="headers"
+          :elements="visibleStations"
+          :selected="selectedStation"
+          @select="selectedStation = $event"
+        >
+          <template v-slot:row="row">
+            <td>
+              <nuxt-link :to="'/data/stations/' + row.item.woudc_id">
+                {{ row.item.woudc_id }}
+              </nuxt-link>
+            </td>
+            <td>
+              <span v-if="row.item.gaw_id !== null">
+                <a :href="row.item.gaw_url" target="_blank">
+                  {{ row.item.gaw_id }}
+                </a>
+              </span>
+            </td>
+            <td>{{ row.item.start_date }}</td>
+            <td>{{ row.item.end_date }}</td>
+            <td>{{ row.item.name }}</td>
+            <td>{{ row.item.country_name[$i18n.locale] }}</td>
+            <td>{{ row.item.last_validated_datetime }}</td>
+            <td>{{ row.item.type }}</td>
+            <td>{{ row.item.wmo_region_id }}</td>
+          </template>
+        </selectable-table>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,103 +1,107 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h2>{{ $t('common.welcome') }}</h2>
-    <v-card itemscope itemtype="http://schema.org/GovernmentOrganization">
-      <v-card-title itemprop="name">
-        WOUDC
-      </v-card-title>
-      <v-card-subtitle itemprop="description">
-        {{ $t('home.adTitle') }}
-      </v-card-subtitle>
-      <v-container class="d-flex justify-start">
-        <v-card
-          max-width="400"
-          class="ma-2"
-          itemprop="memberOf"
-          itemscope
-          itemtype="http://schema.org/GovernmentOrganization"
-        >
-          <div class="d-flex flex-no-wrap justify-space-between">
-            <div>
-              <v-card-title class="headline">
-                <a :href="wmoURL" target="_blank" itemprop="name">
+  <v-container>
+    <v-row>
+      <v-col>
+        <h2>{{ $t('common.welcome') }}</h2>
+        <v-card itemscope itemtype="http://schema.org/GovernmentOrganization">
+          <v-card-title itemprop="name">
+            WOUDC
+          </v-card-title>
+          <v-card-subtitle itemprop="description">
+            {{ $t('home.adTitle') }}
+          </v-card-subtitle>
+          <v-container class="d-flex justify-start">
+            <v-card
+              max-width="400"
+              class="ma-2"
+              itemprop="memberOf"
+              itemscope
+              itemtype="http://schema.org/GovernmentOrganization"
+            >
+              <div class="d-flex flex-no-wrap justify-space-between">
+                <div>
+                  <v-card-title class="headline">
+                    <a :href="wmoURL" target="_blank" itemprop="name">
+                      {{ $t('common.wmo') }}
+                    </a>
+                  </v-card-title>
+                  <v-card-subtitle>
+                    {{ $t('common.wmoFull') }}
+                  </v-card-subtitle>
+                </div>
+                <v-avatar class="ma-3" size="150" tile>
+                  <a target="_blank" :href="wmoURL" itemprop="url">
+                    <v-img
+                      :src="require('~/assets/wmo_acronym_vertical_sm.jpg')"
+                      :alt="$t('home.wmoLogo')"
+                      width="111"
+                      height="150"
+                      itemprop="logo"
+                    />
+                  </a>
+                </v-avatar>
+              </div>
+            </v-card>
+            <v-card
+              max-width="400"
+              class="ma-2"
+              itemprop="memberOf"
+              itemscope
+              itemtype="http://schema.org/GovernmentOrganization"
+            >
+              <div class="d-flex flex-no-wrap justify-space-between">
+                <div>
+                  <v-card-title class="headline">
+                    <a target="_blank" :href="gawURL" itemprop="name">
+                      {{ $t('common.gaw') }}
+                    </a>
+                  </v-card-title>
+                  <v-card-subtitle>
+                    {{ $t('common.gawFull') }}
+                  </v-card-subtitle>
+                </div>
+                <v-avatar class="ma-3" size="150" tile>
+                  <a :href="gawURL" target="_blank" itemprop="url">
+                    <v-img
+                      :src="require('~/assets/gaw_acronym_vertical_sm.jpg')"
+                      :alt="$t('home.gawLogo')"
+                      width="102"
+                      height="150"
+                      itemprop="logo"
+                    />
+                  </a>
+                </v-avatar>
+              </div>
+            </v-card>
+          </v-container>
+          <v-card-text itemprop="description">
+            <i18n path="home.blurb" tag="span">
+              <template v-slot:wmo>
+                <a :href="wmoURL" target="_blank">
                   {{ $t('common.wmo') }}
                 </a>
-              </v-card-title>
-              <v-card-subtitle>
-                {{ $t('common.wmoFull') }}
-              </v-card-subtitle>
-            </div>
-            <v-avatar class="ma-3" size="150" tile>
-              <a target="_blank" :href="wmoURL" itemprop="url">
-                <v-img
-                  :src="require('~/assets/wmo_acronym_vertical_sm.jpg')"
-                  :alt="$t('home.wmoLogo')"
-                  width="111"
-                  height="150"
-                  itemprop="logo"
-                />
-              </a>
-            </v-avatar>
-          </div>
-        </v-card>
-        <v-card
-          max-width="400"
-          class="ma-2"
-          itemprop="memberOf"
-          itemscope
-          itemtype="http://schema.org/GovernmentOrganization"
-        >
-          <div class="d-flex flex-no-wrap justify-space-between">
-            <div>
-              <v-card-title class="headline">
-                <a target="_blank" :href="gawURL" itemprop="name">
+              </template>
+              <template v-slot:gaw>
+                <a :href="gawURL" target="_blank">
                   {{ $t('common.gaw') }}
                 </a>
-              </v-card-title>
-              <v-card-subtitle>
-                {{ $t('common.gawFull') }}
-              </v-card-subtitle>
-            </div>
-            <v-avatar class="ma-3" size="150" tile>
-              <a :href="gawURL" target="_blank" itemprop="url">
-                <v-img
-                  :src="require('~/assets/gaw_acronym_vertical_sm.jpg')"
-                  :alt="$t('home.gawLogo')"
-                  width="102"
-                  height="150"
-                  itemprop="logo"
-                />
-              </a>
-            </v-avatar>
-          </div>
+              </template>
+            </i18n>
+          </v-card-text>
+          <v-card-actions>
+            <v-btn
+              :to="localePath('about')"
+              :title="$t('home.aboutWoudc')"
+              color="primary"
+              nuxt
+            >
+              {{ $t('home.learnMore') }}
+            </v-btn>
+          </v-card-actions>
         </v-card>
-      </v-container>
-      <v-card-text itemprop="description">
-        <i18n path="home.blurb" tag="span">
-          <template v-slot:wmo>
-            <a :href="wmoURL" target="_blank">
-              {{ $t('common.wmo') }}
-            </a>
-          </template>
-          <template v-slot:gaw>
-            <a :href="gawURL" target="_blank">
-              {{ $t('common.gaw') }}
-            </a>
-          </template>
-        </i18n>
-      </v-card-text>
-      <v-card-actions>
-        <v-btn
-          :to="localePath('about')"
-          :title="$t('home.aboutWoudc')"
-          color="primary"
-          nuxt
-        >
-          {{ $t('home.learnMore') }}
-        </v-btn>
-      </v-card-actions>
-    </v-card>
-  </v-layout>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/resources/index.vue
+++ b/pages/resources/index.vue
@@ -1,19 +1,23 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h2>{{ $t('resources.title') }}</h2>
-    <ul>
-      <li v-for="path in localLinks" :key="path">
-        <nuxt-link :to="localePath('resources-' + path)">
-          {{ $t('resources.links.' + path) }}
-        </nuxt-link>
-      </li>
-      <li>
-        <a :href="softwareURL" target="_blank">
-          {{ $t('resources.links.software') }}
-        </a>
-      </li>
-    </ul>
-  </v-layout>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h2>{{ $t('resources.title') }}</h2>
+        <ul>
+          <li v-for="path in localLinks" :key="path">
+            <nuxt-link :to="localePath('resources-' + path)">
+              {{ $t('resources.links.' + path) }}
+            </nuxt-link>
+          </li>
+          <li>
+            <a :href="softwareURL" target="_blank">
+              {{ $t('resources.links.software') }}
+            </a>
+          </li>
+        </ul>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/resources/links.vue
+++ b/pages/resources/links.vue
@@ -1,23 +1,27 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('resources.related-links.title') }}</h1>
-    <h2>{{ $t('common.wmo') }}</h2>
-    <ul>
-      <li v-for="(value, key) in wmoURLs" :key="key">
-        <a :href="value" target="_blank">
-          {{ $t('resources.related-links.links.' + key) }}
-        </a>
-      </li>
-    </ul>
-    <h2>{{ $t('resources.related-links.other-title') }}</h2>
-    <ul>
-      <li v-for="(value, key) in relatedURLs" :key="key">
-        <a :href="value" target="_blank">
-          {{ $t('resources.related-links.links.' + key) }}
-        </a>
-      </li>
-    </ul>
-  </v-layout>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('resources.related-links.title') }}</h1>
+        <h2>{{ $t('common.wmo') }}</h2>
+        <ul>
+          <li v-for="(value, key) in wmoURLs" :key="key">
+            <a :href="value" target="_blank">
+              {{ $t('resources.related-links.links.' + key) }}
+            </a>
+          </li>
+        </ul>
+        <h2>{{ $t('resources.related-links.other-title') }}</h2>
+        <ul>
+          <li v-for="(value, key) in relatedURLs" :key="key">
+            <a :href="value" target="_blank">
+              {{ $t('resources.related-links.links.' + key) }}
+            </a>
+          </li>
+        </ul>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/resources/sop.vue
+++ b/pages/resources/sop.vue
@@ -1,22 +1,26 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('resources.procedures.title') }}</h1>
-    <p>{{ $t('resources.procedures.blurb') }}</p>
-    <v-data-table
-      :headers="headers"
-      :items="rows"
-      hide-default-footer
-      class="elevation-1"
-    >
-      <template v-slot:item.link="link">
-        <td>
-          <a :href="link.item.to" target="_blank">
-            {{ link.item.text }}
-          </a>
-        </td>
-      </template>
-    </v-data-table>
-  </v-layout>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('resources.procedures.title') }}</h1>
+        <p>{{ $t('resources.procedures.blurb') }}</p>
+        <v-data-table
+          :headers="headers"
+          :items="rows"
+          hide-default-footer
+          class="elevation-1"
+        >
+          <template v-slot:item.link="link">
+            <td>
+              <a :href="link.item.to" target="_blank">
+                {{ link.item.text }}
+              </a>
+            </td>
+          </template>
+        </v-data-table>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>

--- a/pages/resources/workinggroups.vue
+++ b/pages/resources/workinggroups.vue
@@ -1,14 +1,18 @@
 <template>
-  <v-layout justify-center column align-content-center>
-    <h1>{{ $t('resources.working-groups.title') }}</h1>
-    <ul>
-      <li v-for="(value, key) in urls" :key="key">
-        <a :href="value" target="_blank">
-          {{ $t('resources.working-groups.links.' + key) }}
-        </a>
-      </li>
-    </ul>
-  </v-layout>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('resources.working-groups.title') }}</h1>
+        <ul>
+          <li v-for="(value, key) in urls" :key="key">
+            <a :href="value" target="_blank">
+              {{ $t('resources.working-groups.links.' + key) }}
+            </a>
+          </li>
+        </ul>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script>


### PR DESCRIPTION
Removes any (deprecated?) `v-layout` containers that were top-level page elements and replaces them with a `v-row`/`v-col` arrangement inside a `v-container` for good responsiveness.

This change affects almost all pages' files and now all their most-recent-commit messages will be the same, which I find annoying.