### PR TITLE
Remove asyncData

### DIFF
--- a/components/SelectableMap.vue
+++ b/components/SelectableMap.vue
@@ -68,11 +68,15 @@ export default {
       if (newSelection === null) {
         // De-activate old selection (which is necessarily non-null).
         const markerID = oldSelection.identifier + '-marker'
-        this.$refs[markerID][0].mapObject.closePopup()
+        this.$nextTick(() => {
+          this.$refs[markerID][0].mapObject.closePopup()
+        })
       } else if (oldSelection === null) {
         // Make a selection when nothing was selected previously.
         const markerID = newSelection.identifier + '-marker'
-        this.$refs[markerID][0].mapObject.openPopup()
+        this.$nextTick(() => {
+          this.$refs[markerID][0].mapObject.openPopup()
+        })
       } else if (newSelection.identifier !== oldSelection.identifier) {
         // Change from one selection to a different one.
         // Block the close popup event from registering as a selection change.
@@ -82,7 +86,9 @@ export default {
         this.eventLock = false
 
         const newMarkerID = newSelection.identifier + '-marker'
-        this.$refs[newMarkerID][0].mapObject.openPopup()
+        this.$nextTick(() => {
+          this.$refs[newMarkerID][0].mapObject.openPopup()
+        })
       }
     }
   },

--- a/locales/en.json
+++ b/locales/en.json
@@ -982,6 +982,7 @@
         "station": "Station Name",
         "waf_url": "Web Accessible Folder"
       },
+      "instrument-model": "Instrument Model:",
       "instrument-type": "Instrument Type:",
       "station-name": "Station Name:",
       "title": "Instrument List"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -982,6 +982,7 @@
         "station": "Nom de la station",
         "waf_url": "Dossier accessible sur le web"
       },
+      "instrument-model": "Modèle de l’instrument :",
       "instrument-type": "Type d’instrument :",
       "station-name": "Nom de la station :",
       "title": "Liste des instruments"

--- a/pages/contributors/index.vue
+++ b/pages/contributors/index.vue
@@ -62,7 +62,6 @@
 </template>
 
 <script>
-import axios from '~/plugins/axios'
 import { unpackageContributor } from '~/plugins/unpackage'
 
 import mapInstructions from '~/components/MapInstructions'
@@ -76,16 +75,6 @@ export default {
     'selectable-map': SelectableMap,
     'selectable-table': SelectableTable,
     'table-instructions': tableInstructions
-  },
-  async asyncData({ params }) {
-    const contributorsURL = '/collections/contributors/items'
-    const queryParams = 'sortby=acronym:A,project:D'
-
-    const contributorsResponse = await axios.get(contributorsURL + '?' + queryParams)
-
-    return {
-      contributors: contributorsResponse.data.features.map(unpackageContributor)
-    }
   },
   data() {
     return {
@@ -123,6 +112,12 @@ export default {
         })
       }
     }
+  },
+  async created() {
+    await this.$store.dispatch('contributors/download')
+
+    const contributors = this.$store.getters['contributors/all']
+    this.contributors = contributors.map(unpackageContributor)
   },
   nuxtI18n: {
     paths: {

--- a/pages/data/instruments.vue
+++ b/pages/data/instruments.vue
@@ -18,6 +18,9 @@
             <strong>{{ $t('data.instruments.instrument-type') }}</strong>
             <span> {{ element.item.name }}</span>
             <br>
+            <strong>{{ $t('data.instruments.instrument-model') }}</strong>
+            <span> {{ element.item.model }}</span>
+            <br>
             <strong>{{ $t('data.instruments.station-name') }}</strong>
             <nuxt-link :to="'/data/stations/' + element.item.station_id">
               {{ element.item.station_name }}
@@ -65,7 +68,6 @@
 </template>
 
 <script>
-import axios from '~/plugins/axios'
 import { unpackageInstrument } from '~/plugins/unpackage'
 
 import mapInstructions from '~/components/MapInstructions'
@@ -80,16 +82,6 @@ export default {
     'selectable-table': SelectableTable,
     'table-instructions': tableInstructions
   },
-  async asyncData({ params }) {
-    const instrumentsURL = '/collections/instruments/items'
-    const queryParams = 'sortby=dataset:A,station_id:A,name:A,model:A'
-
-    const instrumentsResponse = await axios.get(instrumentsURL + '?' + queryParams)
-
-    return {
-      instruments: instrumentsResponse.data.features.map(unpackageInstrument)
-    }
-  },
   data() {
     return {
       boundingBox: null,
@@ -102,10 +94,10 @@ export default {
       const headerKeys = [
         'name',
         'model',
+        'dataset',
         'start_date',
         'end_date',
         'data_class',
-        'dataset',
         'station',
         'waf_url'
       ]
@@ -121,12 +113,18 @@ export default {
       if (this.boundingBox === null) {
         return this.instruments
       } else {
-        return this.instrument.filter((instrument) => {
+        return this.instruments.filter((instrument) => {
           const coords = this.$L.latLng(instrument.geometry.coordinates)
           return this.boundingBox.contains(coords)
         })
       }
     }
+  },
+  async created() {
+    await this.$store.dispatch('instruments/download')
+
+    const instruments = this.$store.getters['instruments/modelResolution']
+    this.instruments = instruments.map(unpackageInstrument)
   },
   nuxtI18n: {
     paths: {

--- a/pages/data/stations/index.vue
+++ b/pages/data/stations/index.vue
@@ -74,7 +74,6 @@
 </template>
 
 <script>
-import axios from '~/plugins/axios'
 import { unpackageStation } from '~/plugins/unpackage'
 
 import mapInstructions from '~/components/MapInstructions'
@@ -88,16 +87,6 @@ export default {
     'selectable-map': SelectableMap,
     'selectable-table': SelectableTable,
     'table-instructions': tableInstructions
-  },
-  async asyncData() {
-    const stationsURL = '/collections/stations/items'
-    const queryParams = 'sortby=woudc_id:A'
-
-    const stationsResponse = await axios.get(stationsURL + '?' + queryParams)
-
-    return {
-      stations: stationsResponse.data.features.map(unpackageStation)
-    }
   },
   data() {
     return {
@@ -137,6 +126,12 @@ export default {
         })
       }
     }
+  },
+  async created() {
+    await this.$store.dispatch('stations/download')
+
+    const stations = this.$store.getters['stations/all'].orderByID
+    this.stations = stations.map(unpackageStation)
   },
   nuxtI18n: {
     paths: {

--- a/store/contributors.js
+++ b/store/contributors.js
@@ -1,0 +1,73 @@
+
+import axios from '~/plugins/axios'
+
+
+const state = () => ({
+  loaded: false,
+  contributorsList: [],
+  contributorsByAcronym: {}
+})
+
+
+const getters = {
+  all(state) {
+    return state.contributorsList
+  },
+  getWithAcronym(state) {
+    return (acronym) => {
+      if (acronym in state.contributorsByAcronym) {
+        return state.contributorsByAcronym[acronym]
+      } else {
+        return null
+      }
+    }
+  }
+}
+
+
+const mutations = {
+  setContributors(state, contributors) {
+    const byAcronym = {}
+
+    contributors.forEach((contributor) => {
+      const acronym = contributor.properties.acronym
+      if (!(acronym in byAcronym)) {
+        byAcronym[acronym] = [ contributor ]
+      } else {
+        byAcronym[acronym].push(contributor)
+      }
+    })
+
+    state.contributorsList = contributors
+    state.contributorsByAcronym = byAcronym
+  },
+  setLoaded(state) {
+    state.loaded = true
+  }
+}
+
+
+const actions = {
+  async download({ commit, state }, proc) {
+    if (state.loaded) {
+      return false
+    }
+
+    const contributorsURL = '/collections/contributors/items'
+    const queryParams = 'sortby=acronym:A&limit=1000'
+
+    const response = await axios.get(contributorsURL + '?' + queryParams)
+
+    commit('setContributors', response.data.features)
+    commit('setLoaded', true)
+  }
+}
+
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations
+}

--- a/store/instruments.js
+++ b/store/instruments.js
@@ -1,0 +1,76 @@
+
+import axios from '~/plugins/axios'
+
+
+const state = () => ({
+  loaded: false,
+  instrumentModels: []  // List of unique instrument name/model combinations.
+})
+
+
+const getters = {
+  // Returns a list of unique instrument name/model combinations.
+  modelResolution(state) {
+    return state.instrumentModels
+  }
+}
+
+
+const mutations = {
+  setInstrumentsModelResolution(state, instruments) {
+    state.instrumentModels = instruments
+  },
+  setLoaded(state) {
+    state.loaded = true
+  }
+}
+
+
+const actions = {
+  async download({ commit, state }, proc) {
+    if (state.loaded) {
+      return false
+    }
+
+    const contributionsURL = '/collections/contributions/items'
+    const queryParams = 'sortby=instrument_name:A,instrument_model:A&limit=5000'
+
+    const response = await axios.get(contributionsURL + '?' + queryParams)
+    const instruments = response.data.features
+
+    const wafRoot = 'https://woudc.org/archive/Archive-NewFormat'
+    const shipIDs = [ '146', '188', '212', '440', '521' ]
+
+    // Eventually replace all this manual organization with a pygeoapi endpoint
+    // that describes all instrument name/model combinations.
+    instruments.forEach((instrument) => {
+      instrument.properties.name = instrument.properties.instrument_name
+      instrument.properties.model = instrument.properties.instrument_model
+
+      delete instrument.properties.instrument_name
+      delete instrument.properties.instrument_model
+
+      const dataset = instrument.properties.dataset
+      const network = instrument.properties.name.toLowerCase()
+
+      const stationID = instrument.properties.station_id
+      const stationType = stationID in shipIDs ? 'SHP' : 'STN'
+      const stationKey = stationType.toLowerCase() + stationID
+
+      const wafURL = `${wafRoot}/${dataset}_1.0_1/${stationKey}/${network}`
+      instrument.properties.waf_url = wafURL
+    })
+
+    commit('setInstrumentsModelResolution', response.data.features)
+    commit('setLoaded', true)
+  }
+}
+
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations
+}


### PR DESCRIPTION
Wherever queries inside an `asyncData()` method were used to get initial state, these queries have been moved either into the `created()` method or into a vuex store that is accessed by the `created()` method.

The motivation is that `asyncData` somehow does not update after the page has been deployed, and so updates to databases would not be seen on the pages that rely on them.