### PR TITLE
Display Loading States

### DIFF
--- a/components/SelectableMap.vue
+++ b/components/SelectableMap.vue
@@ -35,6 +35,9 @@
           </l-popup>
         </l-marker>
       </l-feature-group>
+      <v-overlay absolute opacity="0.66" z-index="1000" :value="loading">
+        <v-progress-circular indeterminate />
+      </v-overlay>
     </l-map>
   </client-only>
 </template>
@@ -45,7 +48,8 @@ export default {
   props: {
     elements: { type: Array, required: true },
     selected: { type: Object, required: false, default: null },
-    country: { type: String, required: false, default: null }
+    country: { type: String, required: false, default: null },
+    loading: { type: Boolean, required: false, default: false }
   },
   data() {
     return {

--- a/components/SelectableTable.vue
+++ b/components/SelectableTable.vue
@@ -5,6 +5,7 @@
     :items="elements"
     :items-per-page="rowsPerPage"
     :page="selectedPage"
+    :loading="loading"
     class="elevation-1"
     @update:items-per-page="rowsPerPage = $event; jumpToSelection()"
   >
@@ -25,7 +26,8 @@ export default {
   props: {
     elements: { type: Array, required: true },
     headers: { type: Array, required: true },
-    selected: { type: Object, required: false, default: null }
+    selected: { type: Object, required: false, default: null },
+    loading: { type: Boolean, required: false, default: false }
   },
   data() {
     return {

--- a/pages/contributors/_id.vue
+++ b/pages/contributors/_id.vue
@@ -14,6 +14,7 @@
         <selectable-map
           :elements="contributors"
           :selected="selectedContributor"
+          :loading="loadingMap"
           @select="selectedContributor = $event"
         >
           <template v-slot:popup="element">
@@ -37,6 +38,7 @@
         <v-data-table
           :headers="contributorHeaders"
           :items="contributors"
+          :loading="loadingTables"
           hide-default-footer
           class="elevation-1"
         >
@@ -58,6 +60,7 @@
           id="deployments-table"
           :headers="deploymentHeaders"
           :items="deployments"
+          :loading="loadingTables"
           class="elevation-1"
         >
           <template v-slot:item="deployment">
@@ -110,6 +113,8 @@ export default {
     return {
       contributors: [],
       deployments: [],
+      loadingMap: true,
+      loadingTables: true,
       selectedContributor: null
     }
   },
@@ -157,8 +162,9 @@ export default {
   },
   async created() {
     await this.$store.dispatch('contributors/download')
-
-    this.populate()
+    await this.populate()
+    this.loadingMap = false
+    this.loadingTables = false
   },
   methods: {
     async populate() {

--- a/pages/contributors/index.vue
+++ b/pages/contributors/index.vue
@@ -11,6 +11,7 @@
         <selectable-map
           :elements="contributors"
           :selected="selectedContributor"
+          :loading="loadingMap"
           @select="selectedContributor = $event"
           @move="boundingBox = $event"
         >
@@ -36,6 +37,7 @@
           :elements="visibleContributors"
           :headers="headers"
           :selected="selectedContributor"
+          :loading="loadingTable"
           @select="selectedContributor = $event"
         >
           <template v-slot:row="row">
@@ -80,6 +82,8 @@ export default {
     return {
       boundingBox: null,
       contributors: [],
+      loadingMap: true,
+      loadingTable: true,
       selectedContributor: null
     }
   },
@@ -118,6 +122,8 @@ export default {
 
     const contributors = this.$store.getters['contributors/all']
     this.contributors = contributors.map(unpackageContributor)
+    this.loadingMap = false
+    this.loadingTable = false
   },
   nuxtI18n: {
     paths: {

--- a/pages/data/instruments.vue
+++ b/pages/data/instruments.vue
@@ -11,6 +11,7 @@
         <selectable-map
           :elements="instruments"
           :selected="selectedInstrument"
+          :loading="loadingMap"
           @select="selectedInstrument = $event"
           @move="boundingBox = $event"
         >
@@ -42,6 +43,7 @@
           :headers="headers"
           :elements="visibleInstruments"
           :selected="selectedInstrument"
+          :loading="loadingTable"
           @select="selectedInstrument = $event"
         >
           <template v-slot:row="row">
@@ -86,6 +88,8 @@ export default {
     return {
       boundingBox: null,
       instruments: [],
+      loadingMap: true,
+      loadingTable: true,
       selectedInstrument: null
     }
   },
@@ -125,6 +129,8 @@ export default {
 
     const instruments = this.$store.getters['instruments/modelResolution']
     this.instruments = instruments.map(unpackageInstrument)
+    this.loadingMap = false
+    this.loadingTable = false
   },
   nuxtI18n: {
     paths: {

--- a/pages/data/stations/_id.vue
+++ b/pages/data/stations/_id.vue
@@ -15,6 +15,7 @@
           v-if="station !== null"
           :elements="[station]"
           :selected="selectedStation"
+          :loading="loadingMap"
           @select="selectedStation = $event"
         >
           <template v-slot:popup="element">
@@ -47,6 +48,7 @@
           v-if="station !== null"
           :headers="stationHeaders"
           :items="[station]"
+          :loading="loadingTables"
           hide-default-footer
           class="elevation-1"
         >
@@ -71,6 +73,7 @@
           id="deployments-table"
           :headers="deploymentHeaders"
           :items="deployments"
+          :loading="loadingTables"
           hide-default-footer
           class="elevation-1"
         >
@@ -97,6 +100,7 @@
           id="instruments-table"
           :headers="instrumentHeaders"
           :items="instruments"
+          :loading="loadingTables"
           class="elevation-1"
         >
           <template v-slot:item.waf_url="instrument">
@@ -139,6 +143,8 @@ export default {
     return {
       deployments: [],
       instruments: [],
+      loadingMap: true,
+      loadingTables: true,
       selectedStation: null,
       station: null
     }
@@ -207,8 +213,9 @@ export default {
   },
   async created() {
     await this.$store.dispatch('stations/download')
-
-    this.populate()
+    await this.populate()
+    this.loadingMap = false
+    this.loadingTables = false
   },
   methods: {
     async populate() {

--- a/pages/data/stations/index.vue
+++ b/pages/data/stations/index.vue
@@ -11,6 +11,7 @@
         <selectable-map
           :elements="stations"
           :selected="selectedStation"
+          :loading="loadingMap"
           @select="selectedStation = $event"
           @move="boundingBox = $event"
         >
@@ -44,6 +45,7 @@
           :headers="headers"
           :elements="visibleStations"
           :selected="selectedStation"
+          :loading="loadingTable"
           @select="selectedStation = $event"
         >
           <template v-slot:row="row">
@@ -91,6 +93,8 @@ export default {
   data() {
     return {
       boundingBox: null,
+      loadingMap: true,
+      loadingTable: true,
       selectedStation: null,
       stations: []
     }
@@ -132,6 +136,8 @@ export default {
 
     const stations = this.$store.getters['stations/all'].orderByID
     this.stations = stations.map(unpackageStation)
+    this.loadingMap = false
+    this.loadingTable = false
   },
   nuxtI18n: {
     paths: {


### PR DESCRIPTION
Shows loading bars at the bottom of many form inputs, using Vuetify's `:loading` props.
Greys out maps and adds a spinner on top while maps are being loaded.
Disables many of these inputs while they are being loaded, and disables "Reset" buttons while anything else is being loaded.

Affects the search page, product pages, and the list-type pages (stations, contributors, instruments). The station order switch on the product pages is also replaced with a set of inline radio buttons.