### PR TITLE
News and Dataset Info Stubs

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -965,27 +965,39 @@
     },
     "info": {
       "blurb": "The WOUDC data archive can provide high level information about each dataset. Select a dataset of interest to see its ISO discovery metadata and a contextual map of the stations.",
+      "descriptors": {
+        "abstract": "Abstract:",
+        "category": "ISO Topic Category:",
+        "doi": "DOI:",
+        "keywords": "Keywords:",
+        "links": "Access Links:",
+        "map": "Station Map",
+        "range": "Temporal Extent:",
+        "range-template": "From {start} to {end}",
+        "title": "Title:",
+        "uri": "Dataset URI:"
+      },
+      "links": {
+        "broadband": "Broad-band",
+        "lidar": "Lidar",
+        "multiband": "Multi-band",
+        "ozonesonde": "OzoneSonde",
+        "rocketsonde": "RocketSonde",
+        "search-page": "Data Search / Download User Interface",
+        "spectral": "Spectral",
+        "totalozone": "Total Ozone - Daily Observations",
+        "totalozoneobs": "Total Ozone - Hourly Observations",
+        "umkehr1": "UmkehrN14 (Level 1.0)",
+        "umkehr2": "UmkehrN14 (Level 2.0)",
+        "uvindex": "UV Index",
+        "waf": "Web Accessible Folder (WAF)",
+        "wfs": "OGC Web Feature Service (WFS)",
+        "wms": "OGC Web Map Service (WMS)"
+      },
       "sections": {
-        "totalozone": {
-          "daily": "Total Ozone - Daily Observations",
-          "hourly": "Total Ozone - Hourly Observations",
-          "title": "Total Column Ozone"
-        },
-        "vertical-ozone": {
-          "lidar": "Lidar",
-          "ozonesonde": "OzoneSonde",
-          "rocketsonde": "RocketSonde",
-          "title": "Vertical Ozone Profile",
-          "umkehr1": "UmkehrN14 (Level 1.0)",
-          "umkehr2": "UmkehrN14 (Level 2.0)"
-        },
-        "uv-irradiance": {
-          "broadband": "Broadband",
-          "multiband": "Multiband",
-          "spectral": "Spectral",
-          "title": "UV Irradiance",
-          "uv-index": "UV Index"
-        }
+        "totalozone": "Total Column Ozone",
+        "uv-irradiance": "UV Irradiance",
+        "vertical-ozone": "Vertical Ozone Profile"
       },
       "subtitle": "Dataset",
       "title": "Dataset Information:"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -966,30 +966,42 @@
     },
     "info": {
       "blurb": "L'archive de données WOUDC peut fournir des informations de haut niveau sur chaque ensemble de données. Sélectionnez un ensemble de données d'intérêt pour voir ses métadonnées de découverte de l'ISO et une carte contextuelle des stations.",
+      "descriptors": {
+        "abstract": "Abstract :",
+        "category": "Catégorie de sujet ISO :",
+        "doi": "DOI :",
+        "keywords": "Mots-clés :",
+        "links": "Liens d'accès :",
+        "map": "Plan des stations",
+        "range": "Étendue temporelle :",
+        "range-template": "De {start} á {end}",
+        "title": "Titre :",
+        "uri": "URI de l'ensemble de données :"
+      },
+      "links": {
+        "broadband": "Large bande",
+        "lidar": "Lidar",
+        "multiband": "Multibande",
+        "ozonesonde": "Sonde pour l’ozone",
+        "rocketsonde": "RocketSonde",
+        "search-page": "Interface de recherche et téléchargement de données",
+        "spectral": "Spectrale",
+        "totalozone": "Ozone total - observations quotidiennes",
+        "totalozoneobs": "Ozone total - Observations horaires",
+        "umkehr1": "UmkehrN14 (Niveau 1.0)",
+        "umkehr2": "UmkehrN14 (Niveau 2.0)",
+        "uvindex": "Indice UV",
+        "waf": "Dossier accessible sur le web (WAF)",
+        "wfs": "OGC Web Feature Service (WFS)",
+        "wms": "OGC Web Map Service (WMS)"
+      },
       "sections": {
-        "totalozone": {
-          "daily": "Ozone total - observations quotidiennes",
-          "hourly": "Ozone total - Observations horaires",
-          "title": "Colonne d’ozone total"
-        },
-        "vertical-ozone": {
-          "lidar": "Lidar",
-          "ozonesonde": "Sonde pour l’ozone",
-          "rocketsonde": "RocketSonde",
-          "title": "Courbe de répartition verticale de l’ozone",
-          "umkehr1": "UmkehrN14 (Niveau 1.0)",
-          "umkehr2": "UmkehrN14 (Niveau 2.0)"
-        },
-        "uv-irradiance": {
-          "broadband": "Large bande",
-          "multiband": "Multibande",
-          "spectral": "Spectrale",
-          "title": "Rayonnement UV",
-          "uv-index": "Indice UV"
-        }
+        "totalozone": "Colonne d’ozone total",
+        "uv-irradiance": "Rayonnement UV",
+        "vertical-ozone": "Courbe de répartition verticale de l’ozone"
       },
       "subtitle": "Jeu de données",
-      "title": "Information sur les jeux de données:"
+      "title": "Information sur les jeux de données :"
     },
     "instruments": {
       "blurb": "Les archives de données du WOUDC peuvent être classées par instrument. La liste d’instruments comprend le type d’instrument, le nom et le modèle.",

--- a/pages/about/dataaccess.vue
+++ b/pages/about/dataaccess.vue
@@ -114,7 +114,7 @@
           <h2>{{ $t('about.access.waf.title') }}</h2>
           <i18n path="about.access.waf.blurb.body-intro" tag="p">
             <template v-slot:waf>
-              <a :href="wafURL" target="_blank">
+              <a :href="process.env.WAF_URL" target="_blank">
                 {{ $t('common.wafFull') }}
               </a>
             </template>
@@ -350,9 +350,8 @@ export default {
       ogcStandardsURL: 'https://opengeospatial.org/standards/cat',
       ogcURL: 'https://opengeospatial.org/',
       searchHelpURL: 'https://github.com/woudc/woudc/wiki/DataSearchDownloadHowto',
-      wafURL: 'https://woudc.org/archive/',
       wafGuideURL: 'https://github.com/woudc/woudc/wiki/WAFHowto',
-      wafSummaryURL: 'https://woudc.org/archive/Summaries/dataset-snapshots',
+      wafSummaryURL: process.env.WAF_URL + '/Summaries/dataset-snapshots',
       wfsURL: 'https://geo.woudc.org/ows?service=WFS&version=1.1.0&request=GetCapabilities',
       wisURL: 'https://www.wmo.int/pages/prog/www/WIS/',
       wmsURL: 'https://geo.woudc.org/ows?service=WMS&version=1.3.0&request=GetCapabilities',

--- a/pages/about/formats.vue
+++ b/pages/about/formats.vue
@@ -60,15 +60,15 @@ export default {
     return {
       contributorsURL: 'https://guide.woudc.org/en/',
       exampleURLs: {
-        broadband: 'https://woudc.org/archive/Documentation/Examples-extCSV/Broad-band.csv',
-        lidar: 'https://woudc.org/archive/Documentation/Examples-extCSV/Lidar.csv',
-        multiband: 'https://woudc.org/archive/Documentation/Examples-extCSV/Multi-band.csv',
-        ozonesonde: 'https://woudc.org/archive/Documentation/Examples-extCSV/Ozonesonde.csv',
-        spectral: 'https://woudc.org/archive/Documentation/Examples-extCSV/Spectral.csv',
-        totalozone: 'https://woudc.org/archive/Documentation/Examples-extCSV/TotalOzone-Brewer.csv',
-        totalozoneobs: 'https://woudc.org/archive/Documentation/Examples-extCSV/TotalOzoneObs.csv',
-        umkehr1: 'https://woudc.org/archive/Documentation/Examples-extCSV/Umkehr-N_values-Dobson.csv',
-        umkehr2: 'https://woudc.org/archive/Documentation/Examples-extCSV/Umkehr_UMK92Retrieval-Dobson.csv'
+        broadband: process.env.WAF_URL + '/Documentation/Examples-extCSV/Broad-band.csv',
+        lidar: process.env.WAF_URL + '/Documentation/Examples-extCSV/Lidar.csv',
+        multiband: process.env.WAF_URL + '/Documentation/Examples-extCSV/Multi-band.csv',
+        ozonesonde: process.env.WAF_URL + '/Documentation/Examples-extCSV/Ozonesonde.csv',
+        spectral: process.env.WAF_URL + '/Documentation/Examples-extCSV/Spectral.csv',
+        totalozone: process.env.WAF_URL + '/Documentation/Examples-extCSV/TotalOzone-Brewer.csv',
+        totalozoneobs: process.env.WAF_URL + '/Documentation/Examples-extCSV/TotalOzoneObs.csv',
+        umkehr1: process.env.WAF_URL + '/Documentation/Examples-extCSV/Umkehr-N_values-Dobson.csv',
+        umkehr2: process.env.WAF_URL + '/Documentation/Examples-extCSV/Umkehr_UMK92Retrieval-Dobson.csv'
       },
       ozoneDatasets: [ 'lidar', 'ozonesonde', 'totalozone', 'totalozoneobs', 'umkehr1', 'umkehr2' ],
       uvDatasets: [ 'broadband', 'multiband', 'spectral' ]

--- a/pages/about/glossary.vue
+++ b/pages/about/glossary.vue
@@ -23,8 +23,8 @@
               </a>
             </template>
             <template v-slot:waf>
-              <a :href="wafURL" target="_blank">
-                {{ wafURL }}
+              <a :href="process.env.WAF_URL" target="_blank">
+                {{ process.env.WAF_URL }}
               </a>
             </template>
           </i18n>
@@ -39,8 +39,7 @@ export default {
   data() {
     return {
       carcinogensURL: 'https://www.wmo.int/pages/prog/dra/etrp/documents/926E.pdf',
-      w3URL: 'https://www.w3.org/',
-      wafURL: "https://woudc.org/archive"
+      w3URL: 'https://www.w3.org/'
     }
   },
   nuxtI18n: {

--- a/pages/contributors/_id.vue
+++ b/pages/contributors/_id.vue
@@ -12,6 +12,7 @@
     <v-row>
       <v-col>
         <selectable-map
+          v-if="contributors.length !== 0"
           :elements="contributors"
           :selected="selectedContributor"
           :loading="loadingMap"
@@ -180,6 +181,12 @@ export default {
       this.deployments =  deploymentsResponse.data.features.map(unpackageDeployment)
       this.contributors = contributors
       this.selectedContributor = contributors[0]
+    }
+  },
+  nuxtI18n: {
+    paths: {
+      en: '/contributors/:id',
+      fr: '/contributeurs/:id'
     }
   }
 }

--- a/pages/data/datasetinfo/_id.vue
+++ b/pages/data/datasetinfo/_id.vue
@@ -1,0 +1,174 @@
+<template>
+  <v-container>
+    <h1>{{ $t('data.info.title') }} {{ title }}</h1>
+    <v-row>
+      <v-col>
+        <div class="mb-3">
+          <strong>{{ $t('data.info.descriptors.title') }}</strong>&nbsp;
+          <span>{{ title }}</span>
+        </div>
+        <div class="mb-3">
+          <strong>{{ $t('data.info.descriptors.abstract') }}</strong>&nbsp;
+          <span>{{ abstract }}</span>
+        </div>
+        <div class="mb-3">
+          <strong>{{ $t('data.info.descriptors.uri') }}</strong>&nbsp;
+          <a :href="uri" target="_blank">{{ uri }}</a>
+        </div>
+        <div class="mb-3">
+          <strong>{{ $t('data.info.descriptors.doi') }}</strong>&nbsp;
+          <a :href="doiURL" target="_blank">{{ doi }}</a>
+        </div>
+        <div class="mb-3">
+          <strong>{{ $t('data.info.descriptors.range') }}</strong>&nbsp;
+          <i18n path="data.info.descriptors.range-template" tag="span">
+            <template v-slot:start>
+              {{ dateFrom }}
+            </template>
+            <template v-slot:end>
+              {{ dateTo }}
+            </template>
+          </i18n>
+        </div>
+        <div class="mb-3">
+          <strong>{{ $t('data.info.descriptors.category') }}</strong>&nbsp;
+          <span>{{ category }}</span>
+        </div>
+        <div class="mb-3">
+          <strong>{{ $t('data.info.descriptors.keywords') }}</strong>&nbsp;
+          <v-chip v-for="word in keywords" :key="word" label small class="mr-1 mb-1">
+            {{ word }}
+          </v-chip>
+        </div>
+        <div>
+          <strong>{{ $t('data.info.descriptors.links') }}</strong>
+          <ul>
+            <li>
+              <a :href="wafURL" target="_blank">{{ $t('data.info.links.waf') }}</a>
+            </li>
+            <li>
+              <a :href="wfsURL" target="_blank">{{ $t('data.info.links.wfs') }}</a>
+            </li>
+            <li>
+              <a :href="wmsURL" target="_blank">{{ $t('data.info.links.wms') }}</a>
+            </li>
+            <li>
+              <nuxt-link :to="localePath('data-explore')">
+                {{ $t('data.info.links.search-page') }}
+              </nuxt-link>
+            </li>
+          </ul>
+        </div>
+      </v-col>
+      <v-col>
+        <div class="mb-3">
+          <strong>{{ $t('data.info.descriptors.map') }}</strong>
+        </div>
+        <map-instructions />
+        <selectable-map
+          :elements="stations"
+          :loading="loadingMap"
+        >
+          <template v-slot:popup="element">
+            <nuxt-link :to="'/data/stations/' + element.item.woudc_id">
+              <span>{{ stationText(element.item) }}</span>
+            </nuxt-link>
+          </template>
+        </selectable-map>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import { unpackageStation } from '~/plugins/unpackage'
+
+import MapInstructions from '~/components/MapInstructions'
+import SelectableMap from '~/components/SelectableMap'
+
+export default {
+  components: {
+    'map-instructions': MapInstructions,
+    'selectable-map': SelectableMap
+  },
+  data() {
+    return {
+      abstract: null,
+      category: null,
+      dataset: null,
+      dateFrom: null,
+      dateTo: null,
+      doi: null,
+      keywords: [],
+      level: null,
+      loadingMap: true,
+      stations: [],
+      title: null,
+      uri: null
+    }
+  },
+  computed: {
+    doiURL() {
+      return `http://dx.doi.org/${this.doi}`
+    },
+    wafURL() {
+      const baseURL = 'https://woudc.org/archive/Archive-NewFormat'
+      return `${baseURL}/${this.dataset}_${this.level}.0_1`
+    },
+    wfsURL() {
+      return 'TODO'
+    },
+    wmsURL() {
+      return 'TODO'
+    },
+  },
+  created() {
+    this.init()
+  },
+  methods: {
+    async init() {
+      // Future: make an HTTP call to gather dataset info.
+      // For now, add some dummy information as an example of the format.
+      this.dataset = 'TotalOzone'
+      this.level = 1
+
+      this.title = 'TotalOzone - Daily Observations'
+      this.abstract = 'A measurement of the total amount of atmospheric ozone in a given column from the surface to the edge of the atmosphere. Ground based instruments such as spectrophotometers and ozonemeters are used to measure results daily.'
+      this.uri = 'https://geo.woudc.org/def/data/ozone/total-column-ozone/totalozone'
+      this.doi = '10.14287/10000004'
+
+      this.category = 'climatologyMeteorologyAtmosphere'
+      this.keywords = [
+        'total', 'ozone', 'level 1.0', 'level 2.0', 'column',
+        'dobson', 'brewer', 'saoz', 'vassey', 'pion', 'microtops', 'spectral',
+        'hoelper', 'filter', 'atmosphericComposition', 'pollution',
+        'observationPlatform', 'rocketSounding'
+      ]
+
+      this.dateFrom = '1924-08-18'
+      this.dateTo = 'now'
+
+      await this.$store.dispatch('stations/download')
+
+      const getterName = `stations/${this.$route.params.id}`
+      const stations = this.$store.getters[getterName].orderByID
+
+      this.stations = stations.map(unpackageStation)
+      this.loadingMap = false
+    },
+    stationText(station) {
+      if (station.gaw_id === null) {
+        return station.name
+      } else {
+        return station.name + ' (' + station.gaw_id + ')'
+      }
+    }
+  },
+  nuxtI18n: {
+    paths: {
+      en: '/data/info/:id',
+      fr: '/donnees/information/:id'
+    }
+  }
+}
+</script>

--- a/pages/data/datasetinfo/index.vue
+++ b/pages/data/datasetinfo/index.vue
@@ -1,0 +1,58 @@
+<template>
+  <v-container>
+    <h1>{{ $t('data.info.title') }}</h1>
+    <v-row>
+      <v-col>
+        <p>{{ $t('data.info.blurb') }}</p>
+        <h2>{{ $t('data.info.subtitle') }}</h2>
+        <ul>
+          <li v-for="section in sectionOrder" :key="section">
+            <span>{{ $t('data.info.sections.' + section) }}</span>
+            <ul>
+              <li v-for="dataset in links[section]" :key="dataset">
+                <nuxt-link :to="localePath('data-datasetinfo') + '/' + dataset">
+                  {{ $t('data.info.links.' + dataset) }}
+                </nuxt-link>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      links: {
+        totalozone: [
+          'totalozone',
+          'totalozoneobs'
+        ],
+        'uv-irradiance': [
+          'broadband',
+          'multiband',
+          'spectral',
+          'uvindex'
+        ],
+        'vertical-ozone': [
+          'lidar',
+          'ozonesonde',
+          'rocketsonde',
+          'umkehr1',
+          'umkehr2'
+        ]
+      },
+      sectionOrder: [ 'totalozone', 'vertical-ozone', 'uv-irradiance' ]
+    }
+  },
+  nuxtI18n: {
+    paths: {
+      en: '/data/info',
+      fr: '/donnees/information'
+    }
+  }
+}
+</script>

--- a/pages/data/products/index.vue
+++ b/pages/data/products/index.vue
@@ -63,12 +63,12 @@ export default {
         individual: 'http://exp-studies.tor.ec.gc.ca/cgi-bin/dailyMaps'
       },
       relatedLinks: {
-        'totalozone-daily-monthly': 'https://woudc.org/archive/Summaries/TotalOzone',
-        'totalozone-satellite-ground': 'https://woudc.org/archive/Projects-Campaigns/Ground-Sat_Plots/',
-        umkehr: 'https://woudc.org/archive/Summaries/Umkehr',
-        spectral: 'https://woudc.org/archive/Summaries/Spectral_UV',
-        'ozone-zonal': 'https://woudc.org/archive/Projects-Campaigns/ZonalMeans',
-        tost: 'https://woudc.org/archive/products/ozone/vertical-ozone-profile/ozonesonde/1.0/tost'
+        'totalozone-daily-monthly': process.env.WAF_URL + '/Summaries/TotalOzone',
+        'totalozone-satellite-ground': process.env.WAF_URL + '/Projects-Campaigns/Ground-Sat_Plots/',
+        umkehr: process.env.WAF_URL + '/Summaries/Umkehr',
+        spectral: process.env.WAF_URL + '/Summaries/Spectral_UV',
+        'ozone-zonal': process.env.WAF_URL + '/Projects-Campaigns/ZonalMeans',
+        tost: process.env.WAF_URL + '/products/ozone/vertical-ozone-profile/ozonesonde/1.0/tost'
       },
       summariesLinks: {
         'polar-bulletins': 'https://www.wmo.int/pages/prog/arep/gaw/ozone/index.html',

--- a/pages/data/products/ozonesonde.vue
+++ b/pages/data/products/ozonesonde.vue
@@ -252,7 +252,7 @@ export default {
         yearsInRange = [ this.selectedYear ]
       }
 
-      const rootURL = 'https://woudc.org/archive/products/ozone/vertical-ozone-profile/ozonesonde/1.0/'
+      const rootURL = process.env.WAF_URL + '/products/ozone/vertical-ozone-profile/ozonesonde/1.0/'
 
       const stationID = this.selectedStationID
       const stationKey = this.selectedStation.name + ' (' + stationID + ')'

--- a/pages/data/products/totalozone.vue
+++ b/pages/data/products/totalozone.vue
@@ -285,7 +285,7 @@ export default {
         yearsInRange = [ this.selectedYear ]
       }
 
-      const root = 'https://woudc.org/archive/products/ozone/total-column-ozone/totalozone/1.0/'
+      const root = process.env.WAF_URL + '/products/ozone/total-column-ozone/totalozone/1.0/'
 
       const stationID = this.selectedStationID
       const stationKey = this.selectedStation.name + ' (' + stationID + ')'

--- a/pages/data/products/uvindex.vue
+++ b/pages/data/products/uvindex.vue
@@ -281,7 +281,7 @@ export default {
         yearsInRange = [ this.selectedYear ]
       }
 
-      const root = 'https://woudc.org/archive/products/uv-radiation/uv-irradiance/uv_index_hourly/2.0/'
+      const root = process.env.WAF_URL + '/products/uv-radiation/uv-irradiance/uv_index_hourly/2.0/'
 
       const stationID = this.selectedStationID
       const stationKey = this.selectedStation.name + ' (' + stationID + ')'

--- a/pages/data/stations/_id.vue
+++ b/pages/data/stations/_id.vue
@@ -240,6 +240,12 @@ export default {
 
       this.instruments = instrumentsResponse.data.features.map(stripProperties)
     }
+  },
+  nuxtI18n: {
+    paths: {
+      en: '/data/stations/:id',
+      fr: '/donnees/stations/:id'
+    }
   }
 }
 </script>

--- a/pages/news.vue
+++ b/pages/news.vue
@@ -1,0 +1,54 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h1>{{ $t('news.title') }}</h1>
+        <p>{{ $t('news.blurb') }}</p>
+        <v-card v-for="(newsItem, i) in newsCollection" :key="i">
+          <v-card-title class="info">
+            {{ newsItem.title }}
+          </v-card-title>
+          <v-card-subtitle class="info">
+            <span class="blue--text text--darken-3">{{ newsItem.date }}</span>
+            <span class="ml-2">{{ newsItem.keywords.join(',') }}</span>
+          </v-card-subtitle>
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <v-card-text class="pt-3" v-html="newsItem.content" />
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      newsCollection: []
+    }
+  },
+  computed: {
+    woudcLink() {
+      return 'https://woudc.org/home.php?lang=' + this.$i18n.locale
+    }
+  },
+  created() {
+    // Future: make an HTTP call to gather news items.
+    // For now, add one dummy news item as an example of the format.
+
+    const item = {
+      title: 'New Website',
+      date: '2015-02-02',
+      keywords: [ 'new website', 'renewal' ],
+      content: 'Welcome to the renewed WOUDC! Improved data access is one of the major enhancements (see <a href="/woudc-ui/about/data-access">data access summary page</a> for details). As part of the transition the <a href=' + this.woudcLink + '>legacy WOUDC</a> will continue to be available for a short period of time. Users are encouraged to provide feedback through the WOUDC <a href="/woudc-ui/contact">email address</a>.'
+    }
+    this.newsCollection.push(item)
+  },
+  nuxtI18n: {
+    paths: {
+      en: '/news',
+      fr: '/nouvelles'
+    }
+  }
+}
+</script>

--- a/pages/resources/links.vue
+++ b/pages/resources/links.vue
@@ -31,7 +31,7 @@ export default {
       wmoURLs: {
         gawsis: 'https://gawsis.meteoswiss.ch/',
         oscar: 'https://www.wmo-sat.info/oscar/',
-        projects: 'https://woudc.org/archive/Projects-Campaigns',
+        projects: process.env.WAF_URL + '/Projects-Campaigns',
         'wdc-aerosol': 'https://www.gaw-wdca.org/',
         'wdc-ghg': 'https://gaw.kishou.go.jp/',
         'wdc-precip': 'http://wdcpc.org/',

--- a/pages/resources/sop.vue
+++ b/pages/resources/sop.vue
@@ -28,7 +28,7 @@ export default {
   data() {
     return {
       linkURLs: {
-        brewer: 'https://woudc.org/archive/Documentation/SOP_Documents',
+        brewer: process.env.WAF_URL + '/Documentation/SOP_Documents',
         dobson: 'https://www.wmo.int/pages/prog/arep/gaw/documents/GAW183-Dobson-WEB.pdf',
         'ozone-quality': 'https://www.wmo.int/pages/prog/arep/gaw/documents/GAW_201.pdf',
         'uv-quality': 'https://www.wmo.int/pages/prog/arep/gaw/documents/Final_GAW198_18_June.pdf',

--- a/pages/resources/workinggroups.vue
+++ b/pages/resources/workinggroups.vue
@@ -20,9 +20,9 @@ export default {
   data() {
     return {
       urls: {
-        brewer: 'https://woudc.org/archive/Documentation/www/bdms/meetings/',
+        brewer: process.env.WAF_URL + '/Documentation/www/bdms/meetings/',
         dobson: 'http://www.o3soft.eu/dobsonweb/committee.html',
-        umkehr: 'https://woudc.org/archive/Publications/Meeting_Reports/Umkehr_Sub-Committee/'
+        umkehr: process.env.WAF_URL + '/Publications/Meeting_Reports/Umkehr_Sub-Committee/'
       }
     }
   },

--- a/store/stations.js
+++ b/store/stations.js
@@ -13,7 +13,7 @@ function groupStationsByDataset(features, stationsByID) {
   const uvIndexDatasets = [ 'Broad-band', 'Spectral' ]
 
   for (const feature of features) {
-    const dataset = feature.properties.dataset
+    const dataset = feature.properties.dataset_id
     const stationID = feature.properties.station_id
     const station = stationsByID[stationID]
 
@@ -197,8 +197,8 @@ const actions = {
     const contributionInputs = [
       { id: 'index', type: 'text/plain', value: 'contribution' },
       { id: 'distinct', type: 'application/json', value: {
-        orderByID: [ 'station_id', 'dataset' ],
-        orderByName: [ 'station_name', 'dataset' ]
+        orderByID: [ 'station_id', 'dataset_id' ],
+        orderByName: [ 'station_name', 'dataset_id' ]
       } },
       { id: 'source', type: 'application/json', value: [ 'station_id' ] }
     ]


### PR DESCRIPTION
Defines the layout and requirements for the dataset info and news pages using static placeholder data.

Also puts in missing translations for contributor and station dynamic routes, because I just figured out how to do that.