### PR TITLE
Disconnected Links Part 1

### DIFF
--- a/pages/about/dataaccess.vue
+++ b/pages/about/dataaccess.vue
@@ -93,7 +93,7 @@
           <i18n path="about.access.search.blurb.body-intro" tag="p">
             <template v-slot:search>
               <nuxt-link :to="localePath('data-explore')">
-                {{ $t('common.search-page') }}
+                {{ $t('common.search') }}
               </nuxt-link>
             </template>
           </i18n>
@@ -114,7 +114,7 @@
           <h2>{{ $t('about.access.waf.title') }}</h2>
           <i18n path="about.access.waf.blurb.body-intro" tag="p">
             <template v-slot:waf>
-              <a :href="process.env.WAF_URL" target="_blank">
+              <a :href="wafURL" target="_blank">
                 {{ $t('common.wafFull') }}
               </a>
             </template>
@@ -195,7 +195,7 @@
             <h3>{{ $t('about.access.wms.title') }}</h3>
             <i18n path="about.access.wms.blurb" tag="p">
               <template v-slot:wms>
-                <a href="" target="_blank">
+                <a :href="wmsURL" target="_blank">
                   {{ $t('common.wms') }}
                 </a>
               </template>
@@ -207,8 +207,8 @@
               <v-card-text>
                 <i18n class="mb-0" path="about.access.wms.note.body" tag="p">
                   <template v-slot:link>
-                    <a :href="wmsURL" target="_blank">
-                      {{ wmsURL }}
+                    <a :href="wmsAPIURL" target="_blank">
+                      {{ wmsAPIURL }}
                     </a>
                   </template>
                 </i18n>
@@ -219,7 +219,7 @@
             <h3>{{ $t('about.access.wfs.title') }}</h3>
             <i18n path="about.access.wfs.blurb.body-intro" tag="p">
               <template v-slot:wfs>
-                <a href="" target="_blank">
+                <a :href="wfsURL" target="_blank">
                   {{ $t('common.wfs') }}
                 </a>
               </template>
@@ -232,19 +232,19 @@
               <v-card-text>
                 <i18n class="mb-0" path="about.access.wfs.note.body" tag="p">
                   <template v-slot:link>
-                    <a :href="wfsURL" target="_blank">
-                      {{ wfsURL }}
+                    <a :href="wfsAPIURL" target="_blank">
+                      {{ wfsAPIURL }}
                     </a>
                   </template>
                 </i18n>
               </v-card-text>
             </v-card>
           </div>
-          <div id="wps-section">
+          <div id="wps-subsection">
             <h3>{{ $t('about.access.wps.title') }}</h3>
             <i18n path="about.access.wps.blurb" tag="p">
               <template v-slot:wps>
-                <a href="" target="_blank">
+                <a :href="wpsURL" target="_blank">
                   {{ $t('common.wps') }}
                 </a>
               </template>
@@ -256,8 +256,8 @@
               <v-card-text>
                 <i18n class="mb-0" path="about.access.wps.note.body" tag="p">
                   <template v-slot:link>
-                    <a :href="wpsURL" target="_blank">
-                      {{ wpsURL }}
+                    <a :href="wpsAPIURL" target="_blank">
+                      {{ wpsAPIURL }}
                     </a>
                   </template>
                 </i18n>
@@ -293,8 +293,8 @@
             <v-card-text>
               <i18n class="mb-0" path="about.access.iso.note.body" tag="p">
                 <template v-slot:link>
-                  <a :href="isoURL" target="_blank">
-                    {{ isoURL }}
+                  <a :href="isoAPIURL" target="_blank">
+                    {{ isoAPIURL }}
                   </a>
                 </template>
               </i18n>
@@ -302,7 +302,7 @@
           </v-card>
           <i18n path="about.access.iso.blurb-howto" tag="p">
             <template v-slot:how-to>
-              <a href="" target="_blank">
+              <a :href="isoServicesURL" target="_blank">
                 {{ $t('about.access.iso.how-to') }}
               </a>
             </template>
@@ -318,7 +318,7 @@
             </template>
           </i18n>
           <v-card>
-            <v-list id="example-list" dense>
+            <v-list id="example-list" class="pa-0" dense>
               <v-list-item>
                 <a :href="examples.pywoudc" target="_blank">
                   pywoudc
@@ -346,16 +346,22 @@ export default {
       definitionsURL: 'https://geo.woudc.org/def',
       githubURL: 'https://github.com/woudc',
       interoperabilityURL: 'https://www.wmo.int/pages/prog/www/WIS/documents/MOAWMO_OGC.pdf',
-      isoURL: 'https://geo.woudc.org/codelists.xml',
+      isoAPIURL: 'https://geo.woudc.org/codelists.xml',
+      isoURL: 'https://www.isotc211.org/',
+      isoServicesURL: 'https://github.com/woudc/woudc/wiki/WebServicesHowto',
       ogcStandardsURL: 'https://opengeospatial.org/standards/cat',
       ogcURL: 'https://opengeospatial.org/',
       searchHelpURL: 'https://github.com/woudc/woudc/wiki/DataSearchDownloadHowto',
+      wafURL: process.env.WAF_URL,
       wafGuideURL: 'https://github.com/woudc/woudc/wiki/WAFHowto',
-      wafSummaryURL: process.env.WAF_URL + '/Summaries/dataset-snapshots',
-      wfsURL: 'https://geo.woudc.org/ows?service=WFS&version=1.1.0&request=GetCapabilities',
+      wafSummaryURL: 'https://woudc.org/archive/Summaries/dataset-snapshots',
+      wfsAPIURL: 'https://geo.woudc.org/ows?service=WFS&version=1.1.0&request=GetCapabilities',
+      wfsURL: 'https://www.opengeospatial.org/standards/wfs',
       wisURL: 'https://www.wmo.int/pages/prog/www/WIS/',
-      wmsURL: 'https://geo.woudc.org/ows?service=WMS&version=1.3.0&request=GetCapabilities',
-      wpsURL: 'https://geo.woudc.org/wps?service=WPS&version=1.0.0&request=GetCapabilities',
+      wmsAPIURL: 'https://geo.woudc.org/ows?service=WMS&version=1.3.0&request=GetCapabilities',
+      wmsURL: 'https://www.opengeospatial.org/standards/wms',
+      wpsAPIURL: 'https://geo.woudc.org/wps?service=WPS&version=1.0.0&request=GetCapabilities',
+      wpsURL: 'https://www.opengeospatial.org/standards/wps',
       contentsSelectors: {
         csw: 'csw-subsection',
         definitions: 'definitions-service-section',

--- a/pages/about/datapolicy.vue
+++ b/pages/about/datapolicy.vue
@@ -121,8 +121,8 @@ export default {
         'multiband', 'spectral', 'uv-index'
       ],
       doisURL: 'https://en.wikipedia.org/wiki/Digital_object_identifier',
-      gawURL: 'https://gawsis.meteoswiss.ch/GAWSIS/index.html#/faq',
-      resolution40: 'https://www.wmo.int/pages/about/Resolution40_en.html',
+      gawURL: 'https://gawsis.meteoswiss.ch/GAWSIS/index.html#/faq/',
+      resolution40: 'https://www.wmo.int/pages/prog/hwrp/documents/wmo_827_enCG-XII-Res40.pdf',
       wmoURL: 'https://www.wmo.int/pages/about/exchangingdata_en.html'
     }
   },

--- a/pages/about/dataquality.vue
+++ b/pages/about/dataquality.vue
@@ -23,7 +23,7 @@
         <p>{{ $t('about.quality.sag.blurb.body-standards') }}</p>
         <ul>
           <li v-for="link in sagLinks" :key="link.to">
-            <a :href="link.to">
+            <a :href="link.to" target="_blank">
               {{ link.text }}
             </a> ({{ link.note }})
           </li>

--- a/pages/about/faq.vue
+++ b/pages/about/faq.vue
@@ -14,7 +14,7 @@
             </template>
             <template v-slot:submission>
               <nuxt-link :to="localePath('contributors-submission')">
-                {{ $t('common.submission') }}
+                {{ $tc('common.submission', 1) }}
               </nuxt-link>
             </template>
             <template v-slot:registration-form>
@@ -29,7 +29,7 @@
             </template>
             <template v-slot:search>
               <nuxt-link :to="localePath('data-explore')">
-                {{ $t('common.search-page') }}
+                {{ $t('common.search') }}
               </nuxt-link>
             </template>
             <template v-slot:products>
@@ -68,8 +68,8 @@
 export default {
   data() {
     return {
-      accessibilityURL: 'https://www.tbs-sct.gc.ca/ws-nw/wa-aw/index-eng.asp',
-      usabilityURL: 'https://www.tbs-sct.gc.ca/ws-nw/wu-fe/index-eng.asp',
+      accessibilityURL: 'https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=23601',
+      usabilityURL: 'https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=24227',
       w3cURL: 'https://www.w3.org/WAI/intro/wcag'
     }
   },

--- a/pages/about/glossary.vue
+++ b/pages/about/glossary.vue
@@ -23,8 +23,8 @@
               </a>
             </template>
             <template v-slot:waf>
-              <a :href="process.env.WAF_URL" target="_blank">
-                {{ process.env.WAF_URL }}
+              <a :href="wafURL" target="_blank">
+                {{ wafURL }}
               </a>
             </template>
           </i18n>
@@ -39,7 +39,8 @@ export default {
   data() {
     return {
       carcinogensURL: 'https://www.wmo.int/pages/prog/dra/etrp/documents/926E.pdf',
-      w3URL: 'https://www.w3.org/'
+      w3URL: 'https://www.w3.org/',
+      wafURL: process.env.WAF_URL
     }
   },
   nuxtI18n: {

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -21,7 +21,7 @@
         <i18n path="about.home.blurb.body-access" tag="p">
           <template v-slot:search>
             <nuxt-link :to="localePath('data-explore')">
-              {{ $t('common.search-page') }}
+              {{ $t('common.search') }}
             </nuxt-link>
           </template>
           <template v-slot:access>

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -42,7 +42,7 @@
           <v-card-text>
             <i18n path="contact.note.body" tag="span">
               <template v-slot:privacy-act>
-                <i><a href="privacyActURL" target="_blank">
+                <i><a :href="privacyActURL" target="_blank">
                   {{ $t('common.privacy-act') }}
                 </a></i>
               </template>

--- a/pages/data/instruments.vue
+++ b/pages/data/instruments.vue
@@ -60,7 +60,9 @@
               />
             </td>
             <td>
-              <a :href="row.item.waf_url" target="_blank">TODO</a>
+              <a :href="row.item.waf_url" target="_blank">
+                <v-icon>mdi-file-download</v-icon>
+              </a>
             </td>
           </template>
         </selectable-table>

--- a/pages/resources/links.vue
+++ b/pages/resources/links.vue
@@ -40,13 +40,13 @@ export default {
       },
       relatedURLs: {
         avdc: 'https://avdc.gsfc.nasa.gov/',
-        crdp: 'http://cci.esa.int/ozone/?q=node/160',
+        crdp: 'http://cci.esa.int/ozone',
         esrl: 'https://www.esrl.noaa.gov/gmd/dv/data/',
         eubrewnet: 'http://www.eubrewnet.org/cost1207/',
         euvdb: 'https://www1.muk.uni-hannover.de/~seckmeyer/EDUCE/',
         gozcards: 'https://gozcards.jpl.nasa.gov/',
         mozaic: 'http://www.iagos-data.fr/',
-        ndacc: 'https://www.ndsc.ncep.noaa.gov/data/',
+        ndacc: 'http://www.ndacc.org/',
         polar: 'http://uv.biospherical.com/',
         uvi: 'https://spacephysics.msfc.nasa.gov/projects/uvi/data_archives.shtml',
         shadoz: 'https://croc.gsfc.nasa.gov/shadoz/'


### PR DESCRIPTION
Fixes a variety of link issues around the site, including local and external links. Fills in some placeholder links with final ones.

A lot of issues come from external sites that were moved, so that links pointed to non-existent places. Some of these have not been fixed yet:
 - First three links under Data Summaries and Reports on the products home page,
 - Item #2 ("more about GAW") on contributor registration page,
 - First link on data quality page, to "GAW quality assurance system",
 - Second link on the standards page, to "WMO Information System",
 - Link under Erythemal on glossary page points somewhere that seems to have little to do with the link text ("carcinogenesis effectiveness").