### PR TITLE
Update news.vue to include filtering by tags

### DIFF
--- a/pages/news.vue
+++ b/pages/news.vue
@@ -13,15 +13,18 @@
     </div>
     <v-row>
       <v-col v-if="loaded">
+        <v-btn class="ma-2" medium rounded @click="tagSelection('reset')">
+          Reset filters
+        </v-btn>
         <v-card v-for="(newsItem, i) in sortedItems" :id="newsItem.properties.published_date.slice(0,10)" :key="i" class="mb-6">
           <v-card-title>
             {{ newsItem.properties[`title_${$i18n.locale}`] }}
           </v-card-title>
           <v-card-subtitle>
             <span class="blue--text text--darken-3">{{ newsItem.properties.published_date.slice(0,10) }}</span>
-            <v-chip v-for="(keyword, j) in newsItem.properties[`keywords_${$i18n.locale}`]" :key="j" class="ma-2" small>
+            <v-btn v-for="(keyword, j) in newsItem.properties[`keywords_${$i18n.locale}`]" :key="j" :class="{ active: selectedElems.includes(keyword), inactive: !selectedElems.includes(keyword) }" rounded small @click="tagSelection(keyword)">
               {{ keyword }}
-            </v-chip>
+            </v-btn>
           </v-card-subtitle>
           <!-- eslint-disable-next-line vue/no-v-html -->
           <v-card-text class="pt-3" v-html="newsItem.properties[`description_${$i18n.locale}`]" />
@@ -37,6 +40,7 @@ export default {
   data(){
     return{
       loaded: false,
+      selectedElems: [],
     }
   },
   computed: {
@@ -46,7 +50,25 @@ export default {
     ...mapState('news',
       ['newsItems']),
     sortedItems(){
-      return this.newsItems.json.features.slice(0).sort((a, b) => a.properties.published_date.slice(0,10) < b.properties.published_date.slice(0,10) ? 1 : -1)
+      let h, i
+      const temp = this.newsItems.json.features.slice(0).sort((a, b) => a.properties.published_date.slice(0,10) < b.properties.published_date.slice(0,10) ? 1 : -1)
+      let sortedItems = []
+      if (this.selectedElems.length===0){ // no particular tags to show: show all news items 
+        sortedItems = temp
+      }
+      else if (this.selectedElems.length>0){ // show only items with all the tags in the list
+        for (i = 0; i < temp.length; i++) {
+          for (h = 0; h < this.selectedElems.length; h++){
+            if (temp[i].properties.keywords_en.includes(this.selectedElems[h]) === false) {
+              break
+            }
+            if (temp[i].properties.keywords_en.includes(this.selectedElems[h]) === true && h === this.selectedElems.length-1) {
+              sortedItems.push(temp[i])
+            }
+          }
+        }
+      }
+      return sortedItems
     }
   },
   created() {
@@ -66,6 +88,18 @@ export default {
       this.loaded = true
       return holder
     },
+    tagSelection(c) {
+      if (c === "reset") { // show all news articles regardless of tags
+        c = ""
+        this.$data.selectedElems = [] 
+      }
+      if (this.$data.selectedElems.includes(c) === true) { 
+        this.$data.selectedElems = this.$data.selectedElems.filter(function(Elem){ return Elem !== c })// arrayRemove(this.$data.selectedElems,c)
+      }
+      else if (c !== "") { 
+        this.$data.selectedElems.push(c) 
+      }
+    }
   },
   head() {
     return {
@@ -87,3 +121,14 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.active {
+  color: rgb(157, 157, 157);
+  margin: 8px 8px;
+}
+.inactive {
+  margin: 8px 8px;
+}
+
+</style>


### PR DESCRIPTION
Enabled filtering of articles so that when a tag is clicked only articles with that particular tag are shown. This can be done for multiple tags at once. If a selected tag is clicked again, it is unselected. A reset button was also added to clear all filtering.