### PR TITLE
WIP: Edit data/search.vue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5511,11 +5511,6 @@
         "defer-to-connect": "^2.0.0"
       }
     },
-    "@trysound/sax": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.1.1.tgz",
-      "integrity": "sha512-Z6DoceYb/1xSg5+e+ZlPZ9v0N16ZvZ+wYMraFue4HYrE4ttONKtsvruIRf6t9TBR0YvSOfi1hUU0fJfBLCDYow=="
-    },
     "@types/babel__core": {
       "version": "7.1.12",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
@@ -16359,10 +16354,8 @@
         },
         "svgo": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.3.0.tgz",
-          "integrity": "sha512-fz4IKjNO6HDPgIQxu4IxwtubtbSfGEAJUq/IXyTPIkGhWck/faiiwfkvsB8LnBkKLvSoyNNIY6d13lZprJMc9Q==",
+          "resolved": "",
           "requires": {
-            "@trysound/sax": "0.1.1",
             "chalk": "^4.1.0",
             "commander": "^7.1.0",
             "css-select": "^3.1.2",

--- a/pages/data/search.vue
+++ b/pages/data/search.vue
@@ -334,6 +334,7 @@ export default {
       countries: [],
       countryOrder: `country_name_${this.$i18n.locale}`,
       numberMatched: 0,
+      numberMatchedLimit: 10000,
       dataRecords: [],
       instruments: [],
       loadingCountries: true,
@@ -847,41 +848,44 @@ export default {
       } else {
         response = await woudcClient.get(dataRecordsURL + '?' + queryParams)
       }
-
+      this.numberMatched =
+        response.data.numberMatched < this.numberMatchedLimit
+          ? response.data.numberMatched
+          : this.numberMatchedLimit
       this.dataRecords = response.data.features.map(stripProperties)
-      this.numberMatched = response.data.numberMatched
 
-      let AllDataRecords = []
-      for (
-        var currStartIndex = 0;
-        currStartIndex < this.numberMatched;
-        currStartIndex += 500
-      ) {
-        if (this.selectedDatasetID === 'uv_index_hourly') {
-          let response = await woudcClient.get(
-            UVIndexURL +
-              '?startindex=' +
-              currStartIndex +
-              '&limit=500&' +
-              queryParams
-          )
-          AllDataRecords = AllDataRecords.concat(
-            response.data.features.map(stripProperties)
-          )
-        } else {
-          let response = await woudcClient.get(
-            dataRecordsURL +
-              '?startindex=' +
-              currStartIndex +
-              '&limit=500&' +
-              queryParams
-          )
-          AllDataRecords = AllDataRecords.concat(
-            response.data.features.map(stripProperties)
-          )
+      if (this.numberMatched > 500) {
+        for (
+          var currStartIndex = 500;
+          currStartIndex < this.numberMatched;
+          currStartIndex += 500
+        ) {
+          console.log(currStartIndex)
+          if (this.selectedDatasetID === 'uv_index_hourly') {
+            let response = await woudcClient.get(
+              UVIndexURL +
+                '?startindex=' +
+                currStartIndex +
+                '&limit=500&' +
+                queryParams
+            )
+            this.dataRecords = this.dataRecords.concat(
+              response.data.features.map(stripProperties)
+            )
+          } else {
+            let response = await woudcClient.get(
+              dataRecordsURL +
+                '?startindex=' +
+                currStartIndex +
+                '&limit=500&' +
+                queryParams
+            )
+            this.dataRecords = this.dataRecords.concat(
+              response.data.features.map(stripProperties)
+            )
+          }
         }
       }
-      this.dataRecords = AllDataRecords
 
       this.oldSearchParams = {
         country: this.selectedCountryID,


### PR DESCRIPTION
Changed query section in data/search.vue to load all the results from the ES query made. After the first 500 results are loaded to the page, the remaining results are loaded in queries producing 500 results at a time. This is time-consuming but I am finding queries for larger datasets are timing out. I am currently looking for alternate solutions.
(https://gccode.ssc-spc.gc.ca/woudc/woudc/-/issues/911)