### PR TITLE
Fixed links to station id pages

### DIFF
--- a/pages/data/instruments.vue
+++ b/pages/data/instruments.vue
@@ -51,7 +51,7 @@
             <td>{{ row.item.dataset }}</td>
             <td>
               <nuxt-link
-                :to="'/data/station/' + row.item.station_id"
+                :to="localePath('data-stations') + '/' + row.item.station_id"
                 v-text="row.item.station_name"
               />
             </td>


### PR DESCRIPTION
Fixed links to station id pages in the Instruments List table to properly direct to English or French station id page.
(Issue 916: https://gccode.ssc-spc.gc.ca/woudc/woudc/-/issues/916)