### PR TITLE
Edit country dropdown list in Data Search / Download page

### DIFF
--- a/pages/data/search.vue
+++ b/pages/data/search.vue
@@ -355,6 +355,7 @@ export default {
       selectedStationID: null,
       selectedYearRange: [null, null],
       stations: [],
+      stationsWithMetadata: [],
       stationOrder: 'name'
     }
   },
@@ -558,6 +559,7 @@ export default {
 
       this.countries = countries.map(stripProperties)
       this.stations = stations.map(unpackageBareStation)
+      this.stationsWithMetadata = stations.map(unpackageBareStation)
       this.instruments = instruments.map(stripProperties)
 
       this.loadingCountries = false
@@ -639,6 +641,8 @@ export default {
       this.loadingInstruments = true
       this.loadingMap = true
 
+      this.selectedCountry = country.element
+      this.selectedCountryID = country.value
       const { stations, instruments } = await this.sendDropdownRequest(
         this.selectedDatasetID,
         country.value,
@@ -670,9 +674,6 @@ export default {
         this.selectedInstrumentID = null
       }
 
-      this.selectedCountry = country.element
-      this.selectedCountryID = country.value
-
       await this.refreshDropdowns()
       this.loadingStations = false
       this.loadingInstruments = false
@@ -701,7 +702,26 @@ export default {
         this.selectedInstrument = null
         this.selectedInstrumentID = null
       }
-      this.refreshMetrics()
+      if (station === null) {
+        this.refreshMetrics()
+      } else {
+        const countryNameProp = `country_name_${this.$i18n.locale}`
+        const stationName =
+          station['name'] === undefined
+            ? station['station_name']
+            : station['name']
+        const countryName = this.stationsWithMetadata[
+          this.stationsWithMetadata.findIndex((s) => s['name'] === stationName)
+        ][countryNameProp]
+        const countryOptionsElems = this.countryOptions.slice(1)
+        const country =
+          countryOptionsElems[
+            countryOptionsElems.findIndex(
+              (c) => c['element'][countryNameProp] === countryName
+            )
+          ]
+        this.changeCountry(country)
+      }
     },
     changeInstrument(instrument) {
       this.selectedInstrument = instrument.element

--- a/pages/data/search.vue
+++ b/pages/data/search.vue
@@ -377,31 +377,10 @@ export default {
 
       const orderedCountries = this.countries
 
-      if (this.mapBoundingBox === null) {
-        const countryOptions = orderedCountries
-          .sort(compareOnKey(this.countryOrder))
-          .map(this.countryToSelectOption)
-        return [nullOption].concat(countryOptions)
-      } else {
-        const boundaries = this.$store.getters['countries/boundaries']
-        const visibleOptions = orderedCountries.filter((country) => {
-          const selected = country.country_id === this.selectedCountryID
-          const countryBoundingBox = boundaries[country.country_id]
-
-          let visible
-          if (countryBoundingBox === null) {
-            visible = this.mapBoundingBox.contains(country.geometry.coordinates)
-          } else {
-            visible = this.mapBoundingBox.intersects(countryBoundingBox)
-          }
-
-          return selected || visible
-        })
-        const countryOptions = visibleOptions
-          .sort(compareOnKey(this.countryOrder))
-          .map(this.countryToSelectOption)
-        return [nullOption].concat(countryOptions)
-      }
+      const countryOptions = orderedCountries
+        .sort(compareOnKey(this.countryOrder))
+        .map(this.countryToSelectOption)
+      return [nullOption].concat(countryOptions)
     },
     dataRecordHeaders() {
       let headerKeys = []

--- a/pages/data/search.vue
+++ b/pages/data/search.vue
@@ -837,6 +837,13 @@ export default {
           queryParams += '&' + field + '=' + value
         }
       }
+      let datetimeParams =
+        this.selectedYearRange[0] +
+        '-01-01T00:00:00Z/' +
+        this.selectedYearRange[1] +
+        '-12-31T23:59:59Z'
+      queryParams = queryParams + '&' + datetimeParams
+
       let response = ''
       if (this.selectedDatasetID === 'uv_index_hourly') {
         response = await woudcClient.get(UVIndexURL + '?' + queryParams)

--- a/pages/data/search.vue
+++ b/pages/data/search.vue
@@ -837,12 +837,18 @@ export default {
           queryParams += '&' + field + '=' + value
         }
       }
-      let datetimeParams =
-        this.selectedYearRange[0] +
-        '-01-01T00:00:00Z/' +
-        this.selectedYearRange[1] +
-        '-12-31T23:59:59Z'
-      queryParams = queryParams + '&' + datetimeParams
+      if (
+        this.selectedYearRange[0] != this.minSelectableYear ||
+        this.selectedYearRange[1] != this.maxSelectableYear
+      ) {
+        let datetimeParams =
+          'datetime=' +
+          this.selectedYearRange[0] +
+          '-01-01T00:00:00Z/' +
+          this.selectedYearRange[1] +
+          '-12-31T23:59:59Z'
+        queryParams = queryParams + '&' + datetimeParams
+      }
 
       let response = ''
       if (this.selectedDatasetID === 'uv_index_hourly') {
@@ -879,8 +885,8 @@ export default {
     },
     async refreshMetrics() {
       const inputs = {
-        'domain': 'contributor',
-        'timescale': 'year'
+        domain: 'contributor',
+        timescale: 'year'
       }
 
       const paramNames = {
@@ -899,7 +905,8 @@ export default {
         ]
         paramNames.bbox = components.join(',')
       }
-      for (const [name, paramValue] of Object.entries(paramNames)) {
+      for (const currParam of Object.entries(paramNames)) {
+        const paramValue = currParam[1]
         if (paramValue === 'uv_index_hourly') {
           // Use spectral for graph until multi dataset metrics are available
           inputs.push({
@@ -929,7 +936,8 @@ export default {
       const inputs = {}
 
       const selections = { dataset, country, station }
-      for (const [domain, selected] of Object.entries(selections)) {
+      for (const currSelection of Object.entries(selections)) {
+        const selected = currSelection[1]
         if (selected === 'uv_index_hourly') {
           inputs.domain = 'Broad-band,Spectral'
         } else if (selected !== null) {

--- a/pages/data/stations/_id.vue
+++ b/pages/data/stations/_id.vue
@@ -346,8 +346,8 @@ export default {
         return {}
       }
       const inputs = {
-        'domain': 'contributor',
-        'timescale': 'year'
+        domain: 'contributor',
+        timescale: 'year'
       }
       const paramNames = {
         dataset: null,
@@ -365,6 +365,7 @@ export default {
         paramNames.bbox = components.join(',')
       }
       for (const [name, paramValue] of Object.entries(paramNames)) {
+        console.log(name)
         if (paramValue !== null) {
           inputs.push({
             name: paramValue

--- a/store/countries.js
+++ b/store/countries.js
@@ -67,11 +67,11 @@ const actions = {
     }
 
     const inputs = {
-      'index': 'contribution',
-      'distinct': {
-          orderByCode: ['country_id']
+      index: 'contribution',
+      distinct: {
+        orderByCode: ['country_id']
       },
-      'source': ['country_id', 'country_name_en', 'country_name_fr']
+      source: ['country_id', 'country_name_en', 'country_name_fr']
     }
 
     const queryParams = { inputs }

--- a/store/instruments.js
+++ b/store/instruments.js
@@ -48,12 +48,12 @@ const actions = {
       this.$config.WOUDC_UI_API +
       '/processes/woudc-data-registry-select-distinct/execution'
     const inputs = {
-      'index': 'instrument',
-      'distinct': {
+      index: 'instrument',
+      distinct: {
         nameResolution: ['name'],
         modelResolution: ['name', 'model', 'station_id', 'dataset']
       },
-      'source': [
+      source: [
         'station_name',
         'data_class',
         'country_name_en',

--- a/store/stations.js
+++ b/store/stations.js
@@ -193,8 +193,8 @@ const actions = {
 
     // Collect arrays of all stations in both ID and name order.
     const stationInputs = {
-      'index': 'station',
-      'distinct': {
+      index: 'station',
+      distinct: {
         orderByID: ['woudc_id']
       }
     }
@@ -225,11 +225,11 @@ const actions = {
 
     // Download all contributions (basically station-dataset pairs)
     const contributionInputs = {
-      'index': 'contribution',
-      'distinct': {
+      index: 'contribution',
+      distinct: {
         orderByID: ['station_id', 'dataset_id']
       },
-      'source': ['station_id']
+      source: ['station_id']
     }
     const queryParams = { inputs: contributionInputs }
 


### PR DESCRIPTION
Edited country dropdown list in data/search.vue so that regardless of how zoomed in to the map you are, the dropdown list of countries always includes all countries, not just the countries visible on the map.  
  
The stations dropdown, however, is narrowed to only the visible stations on the map. The instrument dropdown's options never change. (these dropdowns were not edited)  
  
(additionally, some formatting changes to pass lintfix)  
  
Resolving issue 914: https://gccode.ssc-spc.gc.ca/woudc/woudc/-/issues/914 