### PR TITLE
Edit country dropdown list in Data Search / Download page

### DIFF
--- a/pages/data/search.vue
+++ b/pages/data/search.vue
@@ -378,31 +378,10 @@ export default {
 
       const orderedCountries = this.countries
 
-      if (this.mapBoundingBox === null) {
-        const countryOptions = orderedCountries
-          .sort(compareOnKey(this.countryOrder))
-          .map(this.countryToSelectOption)
-        return [nullOption].concat(countryOptions)
-      } else {
-        const boundaries = this.$store.getters['countries/boundaries']
-        const visibleOptions = orderedCountries.filter((country) => {
-          const selected = country.country_id === this.selectedCountryID
-          const countryBoundingBox = boundaries[country.country_id]
-
-          let visible
-          if (countryBoundingBox === null) {
-            visible = this.mapBoundingBox.contains(country.geometry.coordinates)
-          } else {
-            visible = this.mapBoundingBox.intersects(countryBoundingBox)
-          }
-
-          return selected || visible
-        })
-        const countryOptions = visibleOptions
-          .sort(compareOnKey(this.countryOrder))
-          .map(this.countryToSelectOption)
-        return [nullOption].concat(countryOptions)
-      }
+      const countryOptions = orderedCountries
+        .sort(compareOnKey(this.countryOrder))
+        .map(this.countryToSelectOption)
+      return [nullOption].concat(countryOptions)
     },
     dataRecordHeaders() {
       let headerKeys = []

--- a/pages/data/stations/_id.vue
+++ b/pages/data/stations/_id.vue
@@ -346,8 +346,8 @@ export default {
         return {}
       }
       const inputs = {
-        'domain': 'contributor',
-        'timescale': 'year'
+        domain: 'contributor',
+        timescale: 'year'
       }
       const paramNames = {
         dataset: null,
@@ -365,6 +365,7 @@ export default {
         paramNames.bbox = components.join(',')
       }
       for (const [name, paramValue] of Object.entries(paramNames)) {
+        console.log(name)
         if (paramValue !== null) {
           inputs.push({
             name: paramValue

--- a/store/countries.js
+++ b/store/countries.js
@@ -67,11 +67,11 @@ const actions = {
     }
 
     const inputs = {
-      'index': 'contribution',
-      'distinct': {
-          orderByCode: ['country_id']
+      index: 'contribution',
+      distinct: {
+        orderByCode: ['country_id']
       },
-      'source': ['country_id', 'country_name_en', 'country_name_fr']
+      source: ['country_id', 'country_name_en', 'country_name_fr']
     }
 
     const queryParams = { inputs }

--- a/store/instruments.js
+++ b/store/instruments.js
@@ -48,12 +48,12 @@ const actions = {
       this.$config.WOUDC_UI_API +
       '/processes/woudc-data-registry-select-distinct/execution'
     const inputs = {
-      'index': 'instrument',
-      'distinct': {
+      index: 'instrument',
+      distinct: {
         nameResolution: ['name'],
         modelResolution: ['name', 'model', 'station_id', 'dataset']
       },
-      'source': [
+      source: [
         'station_name',
         'data_class',
         'country_name_en',

--- a/store/stations.js
+++ b/store/stations.js
@@ -193,8 +193,8 @@ const actions = {
 
     // Collect arrays of all stations in both ID and name order.
     const stationInputs = {
-      'index': 'station',
-      'distinct': {
+      index: 'station',
+      distinct: {
         orderByID: ['woudc_id']
       }
     }
@@ -225,11 +225,11 @@ const actions = {
 
     // Download all contributions (basically station-dataset pairs)
     const contributionInputs = {
-      'index': 'contribution',
-      'distinct': {
+      index: 'contribution',
+      distinct: {
         orderByID: ['station_id', 'dataset_id']
       },
-      'source': ['station_id']
+      source: ['station_id']
     }
     const queryParams = { inputs: contributionInputs }
 


### PR DESCRIPTION
Edited country dropdown list in data/search.vue so that regardless of how zoomed in to the map you are, the dropdown list of countries always includes all countries, not just the countries visible on the map.

The stations dropdown, however, is narrowed to only the visible stations on the map. The instrument dropdown's options never change. (these dropdowns were not edited)

(additionally, some formatting changes to pass lintfix)

Resolving issue 914: https://gccode.ssc-spc.gc.ca/woudc/woudc/-/issues/914
(edit of PR 69)