### PR TITLE
Country zoom fix

### DIFF
--- a/components/SelectableMap.vue
+++ b/components/SelectableMap.vue
@@ -74,6 +74,8 @@ export default {
     country(newSelection) {
       if (newSelection !== null) {
         this.autoZoomToCountry(newSelection)
+      } else {
+        this.zoomToGlobe()
       }
     },
     selected(newSelection, oldSelection) {


### PR DESCRIPTION
Addressing issue #924 https://gccode.ssc-spc.gc.ca/woudc/woudc/-/issues/924. When country selection is changed from a specific country to all the map now zooms out and the stations list is updated accordingly.