### PR TITLE
Bbox filtering on Data Search Page

### DIFF
--- a/pages/data/search.vue
+++ b/pages/data/search.vue
@@ -555,6 +555,7 @@ export default {
         const stationOptions = visibleOptions
           .sort(compareOnKey(this.stationOrder))
           .map(this.stationToSelectOption)
+        this.refreshMetrics()
         return [nullOption].concat(stationOptions)
       }
     },

--- a/pages/data/search.vue
+++ b/pages/data/search.vue
@@ -875,6 +875,23 @@ export default {
         }
         queryParams = 'sortby=-timestamp_date,platform_id,content_category'
       }
+
+      if (this.selectedCountry === null && this.selectedStationID === null) {
+        // Select only countries and stations visible on the map
+        let stationIDs = ''
+        for (const station of this.stationOptions) {
+          stationIDs = stationIDs + station['value'] + '|'
+        }
+        if (
+          this.selectedDatasetID === 'uv_index_hourly' ||
+          this.selectedDatasetID === 'TotalOzone'
+        ) {
+          selected['station_id'] = stationIDs
+        } else {
+          selected['platform_id'] = stationIDs
+        }
+      }
+
       for (const [field, value] of Object.entries(selected)) {
         if (value !== null) {
           queryParams += '&' + field + '=' + value
@@ -940,6 +957,22 @@ export default {
         }
         queryParams = 'sortby=-timestamp_date,platform_id,content_category'
       }
+      if (this.selectedCountry === null && this.selectedStationID === null) {
+        // Select only countries and stations visible on the map
+        let stationIDs = ''
+        for (const station of this.stationOptions) {
+          stationIDs = stationIDs + station['value'] + '|'
+        }
+        if (
+          this.selectedDatasetID === 'uv_index_hourly' ||
+          this.selectedDatasetID === 'TotalOzone'
+        ) {
+          selected['station_id'] = stationIDs
+        } else {
+          selected['platform_id'] = stationIDs
+        }
+      }
+
       for (const [field, value] of Object.entries(selected)) {
         if (value !== null) {
           queryParams += '&' + field + '=' + value


### PR DESCRIPTION
Related to issue 919.
Data Search Page:   
 - When the map on the Data Search page is moved, if the group of visible stations (stationOptions) changes, then the metrics chart updates according to what is visible on the map. Currently, the 'Metrics' process is set to take "bbox" as a filter in the UI, but this is not implemented as an input to the API's 'Metrics' process. 

- Update Search Results Table so that if country and station are unselected when you click 'Submit', the results in the Search Results table will only show results for the stations presently visible on the map