### PR TITLE
Edit bbox filtering on Data Search Page

### DIFF
--- a/pages/data/search.vue
+++ b/pages/data/search.vue
@@ -880,20 +880,17 @@ export default {
         queryParams = 'sortby=-timestamp_date,platform_id,content_category'
       }
 
-      if (this.selectedCountry === null && this.selectedStationID === null) {
+      if (
+        this.selectedCountry === null &&
+        this.selectedStationID === null &&
+        this.mapBoundingBox !== null
+      ) {
         // Select only countries and stations visible on the map
-        let stationIDs = ''
-        for (const station of this.stationOptions) {
-          stationIDs = stationIDs + station['value'] + '|'
+        let bboxParams = ''
+        for (const coord of this.boundingBoxArray) {
+          bboxParams = bboxParams + ',' + coord
         }
-        if (
-          this.selectedDatasetID === 'uv_index_hourly' ||
-          this.selectedDatasetID === 'TotalOzone'
-        ) {
-          selected['station_id'] = stationIDs
-        } else {
-          selected['platform_id'] = stationIDs
-        }
+        selected['bbox'] = bboxParams.substring(1)
       }
 
       for (const [field, value] of Object.entries(selected)) {

--- a/pages/data/search.vue
+++ b/pages/data/search.vue
@@ -969,20 +969,17 @@ export default {
         }
         queryParams = 'sortby=-timestamp_date,platform_id,content_category'
       }
-      if (this.selectedCountry === null && this.selectedStationID === null) {
+      if (
+        this.selectedCountry === null &&
+        this.selectedStationID === null &&
+        this.mapBoundingBox !== null
+      ) {
         // Select only countries and stations visible on the map
-        let stationIDs = ''
-        for (const station of this.stationOptions) {
-          stationIDs = stationIDs + station['value'] + '|'
+        let bboxParams = ''
+        for (const coord of this.boundingBoxArray) {
+          bboxParams = bboxParams + ',' + coord
         }
-        if (
-          this.selectedDatasetID === 'uv_index_hourly' ||
-          this.selectedDatasetID === 'TotalOzone'
-        ) {
-          selected['station_id'] = stationIDs
-        } else {
-          selected['platform_id'] = stationIDs
-        }
+        selected['bbox'] = bboxParams.substring(1)
       }
 
       for (const [field, value] of Object.entries(selected)) {
@@ -1100,8 +1097,7 @@ export default {
 
       const countries = response.data.countries.sortby_country_id
       const stations = response.data.stations.sortby_station_id
-      const instruments =
-        response.data.instruments.sortby_instrument_name
+      const instruments = response.data.instruments.sortby_instrument_name
 
       return { countries, stations, instruments }
     },


### PR DESCRIPTION
Data search page: Edit spatial filtering of data records to filter results by bounding  box parameter instead of multiple platform_id parameters, for shorter queries.