### PR TITLE
Edit Station column on Instruments Page Table

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1149,8 +1149,8 @@
         "model": "Instrument Model",
         "name": "Instrument Type",
         "start_date": "Date From",
-        "station": "Station Name",
-        "waf_url": "Web Accessible Folder"
+        "waf_url": "Web Accessible Folder",
+        "station_name": "Station Name"
       },
       "instrument-model": "Instrument Model:",
       "instrument-type": "Instrument Type:",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1149,8 +1149,8 @@
         "model": "Modèle de l’instrument",
         "name": "Type d'instrument",
         "start_date": "À partir de cette date",
-        "station": "Nom de la station",
-        "waf_url": "Dossier accessible sur le web"
+        "waf_url": "Dossier accessible sur le web",
+        "station_name": "Nom de la station"
       },
       "instrument-model": "Modèle de l’instrument :",
       "instrument-type": "Type d’instrument :",

--- a/pages/data/instruments.vue
+++ b/pages/data/instruments.vue
@@ -52,8 +52,9 @@
             <td>
               <nuxt-link
                 :to="localePath('data-stations') + '/' + row.item.station_id"
-                v-text="row.item.station_name"
-              />
+              >
+                {{ row.item.station_name }}
+              </nuxt-link>
             </td>
             <td>
               <a :href="row.item.waf_url" target="_blank">
@@ -100,7 +101,7 @@ export default {
         'start_date',
         'end_date',
         'data_class',
-        'station',
+        'station_name',
         'waf_url'
       ]
 


### PR DESCRIPTION
Changed instruments table header name to station_name to enable column-wise sorting of the Station Name column.