### PR TITLE
Fix Query on Totalozone Products Page

### DIFF
--- a/pages/data/products/totalozone.vue
+++ b/pages/data/products/totalozone.vue
@@ -305,12 +305,12 @@ export default {
       queryParams += '&platform_id=' + this.selectedStationID
 
       if (this.selectedInstrumentID !== null) {
+        let instrument_number = parseInt(
+          this.selectedInstrument.element.properties.serial
+        )
         queryParams +=
           '&instrument_name=' + this.selectedInstrument.element.properties.name
-        queryParams +=
-          '&instrument_number=' +
-          this.selectedInstrument.element.properties.serial +
-          '&limit=5000'
+        queryParams += '&instrument_number=' + instrument_number + '&limit=5000'
       }
 
       const dataRecordsResponse = await woudcClient.get(


### PR DESCRIPTION
Edit query to API, removing leading zeros from instrument model so that the query is able to able to find the instrument in our database.