### PR TITLE
Add Quick Links table to homepage

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1425,9 +1425,10 @@
     "learnMore": "Learn more",
     "news": {
       "more": "More...",
-      "title": "News and Updates"
+      "title": "News and Updates:"
     },
-    "wmoLogo": "Logo: @.wmoFull"
+    "wmoLogo": "Logo: @.wmoFull",
+    "quickLinks": "Quick Links:"
   },
   "news": {
     "blurb": "Data centre news, updates and notifications",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1425,9 +1425,10 @@
     "learnMore": "En savoir plus",
     "news": {
       "more": "Plus...",
-      "title": "Nouvelles et mises à jour"
+      "title": "Nouvelles et mises à jour:"
     },
-    "wmoLogo": "Logo : @.wmoFull"
+    "wmoLogo": "Logo : @.wmoFull",
+    "quickLinks": "Liens rapides:"
   },
   "news": {
     "blurb": "Nouvelles pour le Centre de données, mises à jour et des notifications",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -101,6 +101,12 @@
         </v-card>
       </v-col>
       <v-col cols="12" md="4">
+        <h3 class="h2 mt-2 mb-2">{{ $t('home.quickLinks') }}</h3>
+        <div v-for="linkItem in quickLinks" :key="linkItem">
+          <nuxt-link :to="localePath(linkItem.link)">
+            {{ $t(linkItem.title) }}
+          </nuxt-link>
+        </div>
         <h3 class="h2 mt-2 mb-2">{{ $t('home.news.title') }}</h3>
         <div v-if="loaded">
           <div v-for="(newsItem, i) in recentNewsItems" :key="i">
@@ -145,6 +151,26 @@ export default {
         '/' +
         this.$t('news.title')
       )
+    },
+    quickLinks() {
+      return [
+        {
+          title: 'data.explore.title',
+          link: 'data-search'
+        },
+        {
+          title: 'data.stations.title',
+          link: 'data-stations'
+        },
+        {
+          title: 'data.access.web.title',
+          link: 'data-data_access'
+        },
+        {
+          title: 'resources.related-links.title',
+          link: 'resources-links'
+        }
+      ]
     },
     ...mapState('news', ['newsItems']),
     recentNewsItems() {


### PR DESCRIPTION
Add Quick Links table to homepage, showing links to Data Search, Station List, Web Services, and Resources pages