### PR TITLE
Server-side sorting of Data Search Table

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1063,6 +1063,7 @@
       },
       "table-headers": {
         "actions": "Actions",
+        "agency": "Agency",
         "content-category": "Dataset Name",
         "contributor-acronym": "Agency",
         "country-name_en": "Country",
@@ -1070,12 +1071,14 @@
         "daily-utc_begin": "UTC Time of First Observation",
         "daily-utc_end": "UTC Time of Last Observation",
         "daily-nobs": "Number of Observations",
+        "end-datetime": "UTC Time of Last Observation",
         "file-path": "Actions",
         "gaw-id": "GAW ID",
         "instrument-model": "Instrument Model",
         "instrument-name": "Instrument Name",
         "instrument-type": "Instrument Type",
         "instrument-serial": "Instrument Number",
+        "measurement": "Dataset Name",
         "monthly-date": "Monthly Date",
         "monthly-npts": "Monthly Number of Observations",
         "observation-date": "Observation Date (UTC)",
@@ -1085,6 +1088,7 @@
         "platform-type": "Platform Type",
         "pressure": "Pressure",
         "processed-datetime": "Processed Datetime",
+        "start-datetime": "UTC Time of First Observation",
         "station-gaw_id": "Gaw ID",
         "station-id": "Platform ID",
         "station-name": "Station Name",
@@ -1092,11 +1096,7 @@
         "timestamp-date": "Observation Date (UTC)",
         "timestamp-utc": "Observation Date (UTC)",
         "uv-index": "UV Index Hourly Average",
-        "uv-daily_max": "UV Index Daily Max",
-        "agency": "Agency",
-        "end-datetime": "UTC Time of Last Observation",
-        "start-datetime": "UTC Time of First Observation",
-        "measurement": "Dataset Name"
+        "uv-daily_max": "UV Index Daily Max"
       },
       "title": "Data Search and Download"
     },

--- a/locales/en.json
+++ b/locales/en.json
@@ -1063,7 +1063,6 @@
       },
       "table-headers": {
         "actions": "Actions",
-        "agency": "Agency",
         "content-category": "Dataset Name",
         "contributor-acronym": "Agency",
         "country-name_en": "Country",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1063,7 +1063,6 @@
       },
       "table-headers": {
         "actions": "Actions",
-        "agency": "Organisme",
         "content-category": "Nom de l’ensemble de données",
         "contributor-acronym": "Organisme",
         "country-name_fr": "Pays",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1063,6 +1063,7 @@
       },
       "table-headers": {
         "actions": "Actions",
+        "agency": "Organisme",
         "content-category": "Nom de l’ensemble de données",
         "contributor-acronym": "Organisme",
         "country-name_fr": "Pays",
@@ -1070,12 +1071,14 @@
         "daily-utc_begin": "Heure en UTC de la première observation",
         "daily-utc_end": "Heure en UTC de la dernière observation",
         "daily-nobs": "Nombre d'observations",
+        "end-datetime": "Heure en UTC de la dernière observation",
         "file-path": "Actions",
         "gaw-id": "Identifiant VAG",
         "instrument-model": "Modèle de l’instrument",
         "instrument-name": "Nom de l’instrument",
         "instrument-type": "Type d'instrument",
         "instrument-serial": "Numéro de l’instrument",
+        "measurement": "Nom de l'ensemble de données",
         "monthly-date": "Mensuelle Date",
         "monthly-npts": "Mensuelle Nombre d'observations",
         "observation-date": "Date de l’observation (UTC)",
@@ -1085,6 +1088,7 @@
         "platform-type": "Type de plate-forme",
         "pressure": "Pression",
         "processed-datetime": "Date et heure de traitement",
+        "start-datetime": "Heure en UTC de la première observation",
         "station-name": "Nom de la station",
         "station-gaw_id": "Identifiant VAG",
         "station-id": "Identification de la plate-forme",
@@ -1092,11 +1096,7 @@
         "timestamp-date": "Date de l’observation (UTC)",
         "timestamp-utc": "Date de l’observation (UTC)",
         "uv-index": "Indice UV moyen horaire",
-        "uv-daily_max": "Indice UV jornalier max",
-        "agency": "Organisme",
-        "end-datetime": "Heure en UTC de la dernière observation",
-        "start-datetime": "Heure en UTC de la première observation",
-        "measurement": "Nom de l'ensemble de données"
+        "uv-daily_max": "Indice UV jornalier max"
       },
       "title": "Rechercher et télécharger de données"
     },

--- a/pages/data/search.vue
+++ b/pages/data/search.vue
@@ -329,6 +329,11 @@
                 {{ row.item.observation_time.substring(11, 13) }}
               </p>
             </template>
+            <template v-slot:item.timestamp_utc="row">
+              <p v-if="row.item.timestamp_utc">
+                {{ row.item.timestamp_utc.substring(0, 10) }}
+              </p>
+            </template>
             <template v-slot:item.actions="row">
               <a :href="row.item.url" target="_blank">
                 <v-icon>mdi-file-download</v-icon>
@@ -427,7 +432,7 @@ export default {
         headerKeys = [
           'observation_date',
           'contributor_acronym',
-          'platform_id',
+          'station_id',
           'station_gaw_id',
           this.countryOrder,
           'observation_time',
@@ -443,7 +448,7 @@ export default {
         headerKeys = [
           'observation_date',
           'contributor_acronym',
-          'platform_id',
+          'station_id',
           'station_gaw_id',
           this.countryOrder,
           'monthly_date',
@@ -463,7 +468,7 @@ export default {
         headerKeys = [
           'observation_date',
           'agency',
-          'platform_id',
+          'station_id',
           'gaw_id',
           'measurement',
           'instrument_type',

--- a/pages/data/search.vue
+++ b/pages/data/search.vue
@@ -319,6 +319,11 @@
                 {{ row.item.station_gaw_id }}
               </a>
             </template>
+            <template v-slot:item.gaw_id="row">
+              <a :href="row.item.gaw_url" target="_blank">
+                {{ row.item.gaw_id }}
+              </a>
+            </template>
             <template v-slot:item.contributor_acronym="row">
               <a :href="row.item.contributor_url" target="_blank">
                 {{ row.item.contributor_acronym }}
@@ -467,7 +472,7 @@ export default {
       ) {
         headerKeys = [
           'observation_date',
-          'agency',
+          'contributor_acronym',
           'station_id',
           'gaw_id',
           'measurement',


### PR DESCRIPTION
Enabled server-side sorting of the results table columns on the Data Search & Download page. Sorting by properties of type date (timstamp_utc, processed_datetime) is not presently enabled, so a change must be made to the API to enable sorting for the associated columns.