### PR TITLE
Change items-per-page options on Data Search Table

### DIFF
--- a/pages/data/search.vue
+++ b/pages/data/search.vue
@@ -271,6 +271,9 @@
             :items="dataRecords"
             :options.sync="options"
             :server-items-length="numberMatched"
+            :footer-props="{
+              'items-per-page-options': [10, 25, 50, 100, 500]
+            }"
             :loading="loadingDataRecords"
           >
             <template v-slot:item.observation_date="row">


### PR DESCRIPTION
Change items-per-page options for Data Search results table. Options are [10, 25, 50, 100, 500] (autoset to 10). Resolves issue 935  on GitLab.