### PR TITLE
Bounding box filtering edit on Data Search page

### DIFF
--- a/components/SelectableMap.vue
+++ b/components/SelectableMap.vue
@@ -175,11 +175,10 @@ export default {
 <style>
 #woudc-map {
   height: 520px;
-  width: 520px;
+  width: 100%;
   min-width: 520px;
 
   margin-right: 20px;
-  margin-bottom: 20px;
   z-index: 0;
 }
 </style>

--- a/locales/en.json
+++ b/locales/en.json
@@ -1005,7 +1005,8 @@
         "body-search": "To search and download data, select the dataset and observation time period. Optionally, draw your map extent of interest and then hit search. All available data for that time period will be displayed."
       },
       "bbox": {
-        "title": "Bounding Box",
+        "switch": "Filter by map view",
+        "title": "Map bounds",
         "latitude": {
           "title": "Latitude"
         },

--- a/locales/en.json
+++ b/locales/en.json
@@ -1004,6 +1004,15 @@
         "body-howto": "For more details on how to use this page, please view the {how-to} guide.",
         "body-search": "To search and download data, select the dataset and observation time period. Optionally, draw your map extent of interest and then hit search. All available data for that time period will be displayed."
       },
+      "bbox": {
+        "title": "Bounding Box",
+        "latitude": {
+          "title": "Latitude"
+        },
+        "longitude": {
+          "title": "Longitude"
+        }
+      },
       "country": {
         "id": "Country Code",
         "name": "Country Name",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1004,6 +1004,15 @@
         "body-howto": "Pour obtenir plus d’information à propos de l’utilisation de cette page, consultez le {how-to}.",
         "body-search": "Pour chercher et télécharger des données, sélectionnez l’ensemble de données et la période d’observation. Vous pouvez également choisir l’étendue géographique de votre recherche et cliquer sur envoyer la requête. Toutes les données disponibles pour cette période seront affichées."
       },
+      "bbox": {
+        "title": "Boîte Englobante",
+        "latitude": {
+          "title": "Latitude"
+        },
+        "longitude": {
+          "title": "Longitude"
+        }
+      },
       "country": {
         "id": "Identifiant du Pays",
         "name": "Nom du Pays",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1005,7 +1005,8 @@
         "body-search": "Pour chercher et télécharger des données, sélectionnez l’ensemble de données et la période d’observation. Vous pouvez également choisir l’étendue géographique de votre recherche et cliquer sur envoyer la requête. Toutes les données disponibles pour cette période seront affichées."
       },
       "bbox": {
-        "title": "Boîte Englobante",
+        "switch": "Filtrer par vue de carte",
+        "title": "Limites de la carte",
         "latitude": {
           "title": "Latitude"
         },

--- a/pages/data/search.vue
+++ b/pages/data/search.vue
@@ -185,13 +185,11 @@
             ({{ element.item.woudc_id || element.item.station_id }})
           </template>
         </selectable-map>
-        <v-row justify="center">
-          <v-switch
-            v-model="enableBboxSearch"
-            justify="end"
-            :label="$t('data.explore.bbox.title')"
-          ></v-switch>
-        </v-row>
+        <v-switch
+          v-model="enableBboxSearch"
+          class="float-right"
+          :label="$t('data.explore.bbox.switch')"
+        ></v-switch>
       </v-col>
     </v-row>
     <v-row>

--- a/pages/data/search.vue
+++ b/pages/data/search.vue
@@ -794,6 +794,11 @@ export default {
 
       this.selectedCountry = country.element
       this.selectedCountryID = country.value
+
+      if (country.text !== 'All') {
+        this.enableBboxSearch = false
+      }
+
       const { stations, instruments } = await this.sendDropdownRequest(
         this.selectedDatasetID,
         country.value,
@@ -844,6 +849,7 @@ export default {
       if (station === null) {
         this.selectedStation = null
         this.selectedStationID = null
+        this.enableBboxSearch = false
       } else {
         this.selectedStation = station
         this.selectedStationID = station.woudc_id || station.station_id

--- a/pages/data/search.vue
+++ b/pages/data/search.vue
@@ -168,10 +168,6 @@
           :min="minSelectableYear"
           :max="maxSelectableYear"
         />
-        <v-switch
-          v-model="enableBboxSearch"
-          label="Bounding Box Filtering"
-        ></v-switch>
       </v-col>
       <v-col>
         <map-instructions />
@@ -189,6 +185,13 @@
             ({{ element.item.woudc_id || element.item.station_id }})
           </template>
         </selectable-map>
+        <v-row justify="center">
+          <v-switch
+            v-model="enableBboxSearch"
+            justify="end"
+            :label="$t('data.explore.bbox.title')"
+          ></v-switch>
+        </v-row>
       </v-col>
     </v-row>
     <v-row>
@@ -221,19 +224,8 @@
             small
             class="ml-1"
           >
-            {{ $t('data.explore.bbox.latitude.title')
-            }}{{ $t('common.colon-style') }}
-            {{ latitudeArrayText(boundingBoxArray) }}
-          </v-chip>
-          <v-chip
-            v-if="boundingBoxArray !== null && enableBboxSearch == true"
-            label
-            small
-            class="ml-1"
-          >
-            {{ $t('data.explore.bbox.longitude.title')
-            }}{{ $t('common.colon-style') }}
-            {{ longitudeArrayText(boundingBoxArray) }}
+            {{ $t('data.explore.bbox.title') }}{{ $t('common.colon-style') }}
+            {{ boundingBoxArrayText(boundingBoxArray) }}
           </v-chip>
           <metrics-chart
             :startdate="selectedYearRange[0]"
@@ -792,6 +784,19 @@ export default {
 
       this.refreshMetrics()
     },
+    boundingBoxArrayText(boundingBoxArray) {
+      return (
+        '[ ' +
+        parseFloat(boundingBoxArray[0]).toFixed(2) +
+        ', ' +
+        parseFloat(boundingBoxArray[1]).toFixed(2) +
+        ', ' +
+        parseFloat(boundingBoxArray[2]).toFixed(2) +
+        ', ' +
+        parseFloat(boundingBoxArray[3]).toFixed(2) +
+        ' ]'
+      )
+    },
     async changeCountry(country) {
       this.loadingStations = true
       this.loadingInstruments = true
@@ -928,24 +933,6 @@ export default {
         value: instrument.name || instrument.instrument_name,
         element: instrument
       }
-    },
-    latitudeArrayText(boundingBoxArray) {
-      return (
-        '[ ' +
-        parseFloat(boundingBoxArray[1]).toFixed(2) +
-        ', ' +
-        parseFloat(boundingBoxArray[3]).toFixed(2) +
-        ' ]'
-      )
-    },
-    longitudeArrayText(boundingBoxArray) {
-      return (
-        '[ ' +
-        parseFloat(boundingBoxArray[0]).toFixed(2) +
-        ', ' +
-        parseFloat(boundingBoxArray[2]).toFixed(2) +
-        ' ]'
-      )
     },
     stationText(station) {
       const stationID = station.woudc_id || station.station_id

--- a/pages/data/search.vue
+++ b/pages/data/search.vue
@@ -210,6 +210,16 @@
             }}{{ $t('common.colon-style') }}
             {{ instrumentText(selectedInstrument) }}
           </v-chip>
+          <v-chip v-if="boundingBoxArray !== null" label small class="ml-1">
+            {{ $t('data.explore.bbox.latitude.title')
+            }}{{ $t('common.colon-style') }}
+            {{ latitudeArrayText(boundingBoxArray) }}
+          </v-chip>
+          <v-chip v-if="boundingBoxArray !== null" label small class="ml-1">
+            {{ $t('data.explore.bbox.longitude.title')
+            }}{{ $t('common.colon-style') }}
+            {{ longitudeArrayText(boundingBoxArray) }}
+          </v-chip>
           <metrics-chart
             :startdate="selectedYearRange[0]"
             :enddate="selectedYearRange[1]"
@@ -881,6 +891,24 @@ export default {
         value: instrument.name || instrument.instrument_name,
         element: instrument
       }
+    },
+    latitudeArrayText(boundingBoxArray) {
+      return (
+        '[ ' +
+        parseFloat(boundingBoxArray[1]).toFixed(2) +
+        ', ' +
+        parseFloat(boundingBoxArray[3]).toFixed(2) +
+        ' ]'
+      )
+    },
+    longitudeArrayText(boundingBoxArray) {
+      return (
+        '[ ' +
+        parseFloat(boundingBoxArray[0]).toFixed(2) +
+        ', ' +
+        parseFloat(boundingBoxArray[2]).toFixed(2) +
+        ' ]'
+      )
     },
     stationText(station) {
       const stationID = station.woudc_id || station.station_id


### PR DESCRIPTION
- Add Longitude and Latitude tags to metrics chart (shows bounds of bounding box if filtering by bounding box is enabled)
- Make Data Search filtering by bounding box optional (switch added to the page)
- Disable bounding box filter when a country or station is selected

(related to issue 934)