### PR TITLE
Fix Deployment header names

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -832,12 +832,13 @@
       "contributor-name": "Contributor Name:",
       "country-name": "Country:",
       "deployment-headers": {
-        "country": "Station Country",
+        "country_name_en": "Station Country",
+        "country_name_fr": "Station Country",
         "end_date": "Date To",
-        "name": "Station Name",
+        "station_name": "Station Name",
         "start_date": "Date From",
-        "type": "Station Type",
-        "woudc_id": "WOUDC Station ID"
+        "station_type": "Station Type",
+        "station_id": "WOUDC Station ID"
       },
       "title": "Contributor List"
     },

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -832,12 +832,13 @@
       "contributor-name": "Nom du contributeur :",
       "country-name": "Nom du pays :",
       "deployment-headers": {
-        "country": "Pays de la station",
+        "country_name_en": "Pays de la station",
+        "country_name_fr": "Pays de la station",
         "end_date": "Jusqu’à cette date",
-        "name": "Nom de la station",
+        "station_name": "Nom de la station",
         "start_date": "À partir de cette date",
-        "type": "Type de station",
-        "woudc_id": "Identification de la station du WOUDC"
+        "station_type": "Type de station",
+        "station_id": "Identification de la station du WOUDC"
       },
       "title": "Liste des contributeurs"
     },

--- a/pages/contributors/_id.vue
+++ b/pages/contributors/_id.vue
@@ -141,10 +141,10 @@ export default {
     },
     deploymentHeaders() {
       const deploymentKeys = [
-        'woudc_id',
-        'name',
-        'type',
-        'country',
+        'station_id',
+        'station_name',
+        'station_type',
+        `country_name_${this.$i18n.locale}`,
         'start_date',
         'end_date'
       ]


### PR DESCRIPTION
Correct deployment header names to the corresponding deployment field names to enable sorting of columns on Contributors page.