### PR TITLE
UV Index Products Query Fix

### DIFF
--- a/pages/data/products/uvindex.vue
+++ b/pages/data/products/uvindex.vue
@@ -291,11 +291,21 @@ export default {
       queryParams += '&platform_id=' + this.selectedStationID
 
       if (this.selectedInstrument !== null) {
-        const [name, model, serial] = this.selectedInstrument.split('_')
-
-        queryParams += '&instrument_name=' + name
-        queryParams += '&instrument_model=' + model
-        queryParams += '&instrument_number=' + serial
+        if (this.selectedInstrument.includes('Kipp_Zonen') == true) {
+          const instrument_metadata = this.selectedInstrument.split('_')
+          queryParams +=
+            '&instrument_name=' +
+            instrument_metadata[0] +
+            '_' +
+            instrument_metadata[1]
+          queryParams += '&instrument_model=' + instrument_metadata[2]
+          queryParams += '&instrument_number=' + instrument_metadata[3]
+        } else {
+          const [name, model, serial] = this.selectedInstrument.split('_')
+          queryParams += '&instrument_name=' + name
+          queryParams += '&instrument_model=' + model
+          queryParams += '&instrument_number=' + serial
+        }
       }
 
       const broadbandParams =


### PR DESCRIPTION
Add special case to query formation on UV Index Products page, where the Kipp_Zonen instrument has been selected (instruments with an underscore in their name).