### PR TITLE
Add "Reset" field to locales for News page

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1444,6 +1444,7 @@
   },
   "news": {
     "blurb": "Data centre news, updates and notifications",
+    "reset": "Reset filters",
     "title": "News and Updates"
   },
   "resources": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1444,6 +1444,7 @@
   },
   "news": {
     "blurb": "Nouvelles pour le Centre de données, mises à jour et des notifications",
+    "reset": "Réinitialiser les filtres",
     "title": "Nouvelles et mises à jour"
   },
   "resources": {

--- a/pages/news.vue
+++ b/pages/news.vue
@@ -29,7 +29,7 @@
     <v-row>
       <v-col v-if="loaded">
         <v-btn class="ma-2" medium rounded @click="tagSelection('reset')">
-          Reset filters
+          {{ $t('news.reset') }}
         </v-btn>
         <v-card
           v-for="(newsItem, i) in sortedItems"


### PR DESCRIPTION
Add field for the text on a button on the News page (was previously only in 1 language).