### PR TITLE
Add query params to Data Search page URL

### DIFF
--- a/pages/data/dataset_info/_id.vue
+++ b/pages/data/dataset_info/_id.vue
@@ -72,7 +72,9 @@
               }}</a>
             </li>
             <li>
-              <nuxt-link :to="localePath('data-search')">
+              <nuxt-link
+                :to="localePath('data-search') + '?dataset=' + dataset_id"
+              >
                 {{ $t('data.info.links.search-page') }}
               </nuxt-link>
             </li>
@@ -120,6 +122,7 @@ export default {
       category: null,
       collectionItem: null,
       dataset: null,
+      dataset_id: null,
       dateFrom: null,
       dateTo: null,
       doi: null,
@@ -187,6 +190,7 @@ export default {
       const response = await woudcClient.get(this.uriDatasetDef)
       this.collectionItem = response.data.features[0].properties
 
+      this.dataset_id = this.collectionItem.identifier
       this.title = this.collectionItem[`title_${this.$i18n.locale}`]
       this.abstract = this.collectionItem[`abstract_${this.$i18n.locale}`]
       this.doi = this.collectionItem.doi
@@ -194,9 +198,7 @@ export default {
       this.dateTo = this.collectionItem.temporal_end
       this.category = this.collectionItem.topic_category
       this.keywords = this.collectionItem[`keywords_${this.$i18n.locale}`]
-      if (this.dataset === 'uvindex') {
-        this.wafDataset = null
-      } else {
+      if (this.dataset !== 'uv_index_hourly') {
         this.wafDataset = this.collectionItem.waf[`label_${this.$i18n.locale}`]
       }
     },

--- a/pages/data/search.vue
+++ b/pages/data/search.vue
@@ -750,7 +750,7 @@ export default {
       this.selectedDataset = this.$t('common.all')
       this.selectedYearRange = [this.minSelectableYear, this.maxSelectableYear]
 
-      this.refreshMetrics()
+      this.routingParams()
     })
   },
   methods: {
@@ -872,7 +872,8 @@ export default {
         !(
           station === null ||
           this.peerOrNdaccDatasets.includes(this.selectedDatasetID)
-        )
+        ) &&
+        this.selectedCountry === null
       ) {
         this.selectCountryFromStation(station)
       }
@@ -1292,6 +1293,37 @@ export default {
       })
 
       this.metricsByYear = newMetrics
+    },
+    async routingParams() {
+      if ('dataset' in this.$route.query) {
+        for (const dataset of this.datasetOptions) {
+          if (dataset.value == this.$route.query.dataset) {
+            await this.changeDataset(dataset)
+          }
+        }
+      }
+      if ('country' in this.$route.query) {
+        for (const country of this.countryOptions) {
+          if (country.value == this.$route.query.country) {
+            await this.changeCountry(country)
+          }
+        }
+      }
+      if ('station' in this.$route.query) {
+        for (const station of this.stationOptions) {
+          if (station.value == this.$route.query.station) {
+            await this.changeStation(station.element)
+          }
+        }
+      }
+      if ('instrument' in this.$route.query) {
+        for (const instrument of this.instrumentOptions) {
+          if (instrument.value == this.$route.query.instrument) {
+            await this.changeInstrument(instrument)
+          }
+        }
+      }
+      this.refreshMetrics()
     },
     async sendDropdownRequest(dataset, country, station) {
       const inputs = {}


### PR DESCRIPTION
Enable selection of query parameters (dataset, country, station, instrument) on Data Search page through URL parameters. Update hyperlinks on Dataset Info pages to incorporate this change.