### PR TITLE
Normalozonemaps

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1589,6 +1589,63 @@
         "metaDescription": "Dataset download links and abstract of the {josie}-{besos} data products (@:data.products.josieBesos.title).",
         "josieFullName": "Jülich Ozone Sonde Intercomparison Experiment (JOSIE)",
         "wccosFullName": "World Calibration Centre for Ozone Sondes (WCCOS)"
+      },
+      "normal-ozone-maps": {
+        "title": "Maps of normal ozone",
+        "description": "These maps show the mean 1978-1988 level estimated using Total Ozone Mapping Spectrometer (TOMS) data for all areas except the Antarctic and from the pre-1980 level estimated using Dobson data over the Antarctic.",
+        "keywords": "normal ozone maps, ozone maps, global, southen hemisphere, northern hemisphere, globle, Mean total ozone, total ozone, maps of normal ozone",
+        "global": "Global",
+        "globalDesc": "Mean total ozone by month",
+        "northern": "Northern",
+        "southernDesc": "The mean total ozone by month for the southern hemisphere",
+        "southern": "Southern",
+        "northernDesc": "The mean total ozone by month for the northern hemisphere",
+        "captions": {
+          "globe": {
+            "jan": "The mean total ozone for the globe in January.",
+            "feb": "The mean total ozone for the globle in February.",
+            "mar": "The mean total ozone for the globle in March.",
+            "apr": "The mean total ozone for the globle in April.",
+            "may": "The mean total ozone for the globle in May.",
+            "jun": "The mean total ozone for the globle in June.",
+            "jul": "The mean total ozone for the globle in July.",
+            "aug": "The mean total ozone for the globle in August.",
+            "sept": "The mean total ozone for the globle in September.",
+            "oct": "The mean total ozone for the globle in October.",
+            "nov": "The mean total ozone for the globle in November.",
+            "dec": "The mean total ozone for the globle in December."
+          },
+          "northern": {
+            "jan": "The mean total ozone for the northern hemisphere in January.",
+            "feb": "The mean total ozone for the northern hemisphere in February.",
+            "mar": "The mean total ozone for the northern hemisphere in March.",
+            "apr": "The mean total ozone for the northern hemisphere in April.",
+            "may": "The mean total ozone for the northern hemisphere in May.",
+            "jun": "The mean total ozone for the northern hemisphere in June.",
+            "jul": "The mean total ozone for the northern hemisphere in July.",
+            "aug": "The mean total ozone for the northern hemisphere in August.",
+            "sept": "The mean total ozone for the northern hemisphere in September.",
+            "oct": "The mean total ozone for the northern hemisphere in October.",
+            "nov": "The mean total ozone for the northern hemisphere in November.",
+            "dec": "The mean total ozone for the northern hemisphere in December."
+          },
+          "southern": {
+            "jan": "The mean total ozone for the southern hemisphere in January.",
+            "feb": "The mean total ozone for the southern hemisphere in February.",
+            "mar": "The mean total ozone for the southern hemisphere in March.",
+            "apr": "The mean total ozone for the southern hemisphere in April.",
+            "may": "The mean total ozone for the southern hemisphere in May.",
+            "jun": "The mean total ozone for the southern hemisphere in June.",
+            "jul": "The mean total ozone for the southern hemisphere in July.",
+            "aug": "The mean total ozone for the southern hemisphere in August.",
+            "sept": "The mean total ozone for the southern hemisphere in September.",
+            "oct": "The mean total ozone for the southern hemisphere in October.",
+            "nov": "The mean total ozone for the southern hemisphere in November.",
+            "dec": "The mean total ozone for the southern hemisphere in December."
+          },
+          "beginning": "The mean total ozone for the ",
+          "globle": "globe"
+        }
       }
     },
     "quality": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1584,6 +1584,63 @@
         "metaDescription": "Liens de téléchargement de l'ensemble de données et résumé des produits de données de l'{josie}-{besos} (@:data.products.josieBesos.title).",
         "josieFullName": "Expérience d’Intercomparaison des Sondes d’Ozone de Jülich (EISOJ) ",
         "wccosFullName": "Centre Mondial d’Étalonnage des Sondes d’Ozone (CMESO)"
+      },
+      "normal-ozone-maps": {
+        "title": "Cartes de l'ozone normale",
+        "description": "Ces cartes montrent le niveau moyen de 1978-1988 estimé à l'aide des données du spectromètre de cartographie de l'ozone total (TOMS) pour toutes les zones à l'exception de l'Antarctique, ainsi que le niveau d'avant 1980 estimé à l'aide des données de Dobson au-dessus de l'Antarctique.",
+        "keywords": "cartes normales de l'ozone, cartes de l'ozone, global, hémisphère sud, hémisphère nord, globe, ozone total moyen, ozone total, cartes de l'ozone normal",
+        "global": "Mondial",
+        "northern": "Hémisphère Nord",
+        "southern": "Hémisphère Sud",
+        "globalDesc": "L’ozone total moyen par mois",
+        "northernDesc": "La carte de l’ozone total moyen par mois pour l’hémisphère Nord",
+        "southernDesc": "La carte de l’ozone total moyen par mois pour l’hémisphère Sud",
+        "captions": {
+          "globe": {
+            "jan": "L'ozone total moyen pour le globe en janvier.",
+            "feb": "L'ozone total moyen pour le globe en février.",
+            "mar": "L'ozone total moyen pour le globe en mars.",
+            "apr": "L'ozone total moyen pour le globe en avril.",
+            "may": "L'ozone total moyen pour le globe en mai.",
+            "jun": "L'ozone total moyen pour le globe en juin.",
+            "jul": "L'ozone total moyen pour le globe en juillet.",
+            "aug": "L'ozone total moyen pour le globe en août.",
+            "sept": "L'ozone total moyen pour le globe en septembre.",
+            "oct": "L'ozone total moyen pour le globe en octobre.",
+            "nov": "L'ozone total moyen pour le globe en novembre.",
+            "dec": "L'ozone total moyen pour le globe en décembre."
+          },
+          "northern": {
+            "jan": "L'ozone total moyen pour l’hémisphère Nord en janvier.",
+            "feb": "L'ozone total moyen pour l’hémisphère Nord en février.",
+            "mar": "L'ozone total moyen pour l’hémisphère Nord en mars.",
+            "apr": "L'ozone total moyen pour l’hémisphère Nord en avril.",
+            "may": "L'ozone total moyen pour l’hémisphère Nord en mai.",
+            "jun": "L'ozone total moyen pour l’hémisphère Nord en juin.",
+            "jul": "L'ozone total moyen pour l’hémisphère Nord en juillet.",
+            "aug": "L'ozone total moyen pour l’hémisphère Nord en août.",
+            "sept": "L'ozone total moyen pour l’hémisphère Nord en septembre.",
+            "oct": "L'ozone total moyen pour l’hémisphère Nord en octobre.",
+            "nov": "L'ozone total moyen pour l’hémisphère Nord en novembre.",
+            "dec": "L'ozone total moyen pour l’hémisphère Nord en décembre."
+          },
+          "southern": {
+            "jan": "L'ozone total moyen pour l’hémisphère Sud en janvier.",
+            "feb": "L'ozone total moyen pour l’hémisphère Sud en février.",
+            "mar": "L'ozone total moyen pour l’hémisphère Sud en mars.",
+            "apr": "L'ozone total moyen pour l’hémisphère Sud en avril.",
+            "may": "L'ozone total moyen pour l’hémisphère Sud en mai.",
+            "jun": "L'ozone total moyen pour l’hémisphère Sud en juin.",
+            "jul": "L'ozone total moyen pour l’hémisphère Sud en juillet.",
+            "aug": "L'ozone total moyen pour l’hémisphère Sud en août.",
+            "sept": "L'ozone total moyen pour l’hémisphère Sud en septembre.",
+            "oct": "L'ozone total moyen pour l’hémisphère Sud en octobre.",
+            "nov": "L'ozone total moyen pour l’hémisphère Sud en novembre.",
+            "dec": "L'ozone total moyen pour l’hémisphère Sud en décembre."
+          },
+          "beginning": "L'ozone total moyen pour le",
+          "globle": "globe"
+        }
       }
     },
     "quality": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "woudc-ui",
-  "version": "2.0.0-beta19",
+  "version": "2.0.0-beta20-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "woudc-ui",
-      "version": "2.0.0-beta19",
+      "version": "2.0.0-beta20-dev",
       "dependencies": {
         "@nuxtjs/axios": "^5.12.0",
         "@nuxtjs/i18n": "^7.2.0",

--- a/pages/data/products/index.vue
+++ b/pages/data/products/index.vue
@@ -72,6 +72,13 @@
                 <span>{{ $t('data.products.ozone_maps.titleArchived') }}</span>
               </nuxt-link>
             </li>
+            <li>
+              <nuxt-link
+                :to="`${localePath('data-products-normal-ozone-maps')}`"
+              >
+                <span>{{ $t('data.products.normal-ozone-maps.title') }}</span>
+              </nuxt-link>
+            </li>
           </ul>
         </div>
         <div id="summaries">

--- a/pages/data/products/normal-ozone-maps.vue
+++ b/pages/data/products/normal-ozone-maps.vue
@@ -1,0 +1,145 @@
+<template>
+  <v-container>
+    <h1>{{ $t('data.products.normal-ozone-maps.title') }}</h1>
+    <v-btn-toggle v-model="ozoneMapTab" mandatory>
+      <v-btn value="global">
+        {{ $t('data.products.normal-ozone-maps.global') }}
+      </v-btn>
+      <v-btn value="northern">
+        {{ $t('data.products.normal-ozone-maps.northern') }}
+      </v-btn>
+      <v-btn value="southern">
+        {{ $t('data.products.normal-ozone-maps.southern') }}
+      </v-btn>
+    </v-btn-toggle>
+
+    <section v-if="ozoneMapTab === 'global'">
+      <h2>{{ $t('data.products.normal-ozone-maps.globalDesc') }}</h2>
+      <graph-carousel
+        :key="Object.keys(normalOzoneMapsGlobal)"
+        :graphs="normalOzoneMapsGlobal"
+      ></graph-carousel>
+    </section>
+
+    <section v-if="ozoneMapTab === 'northern'">
+      <h2>{{ $t('data.products.normal-ozone-maps.northernDesc') }}</h2>
+      <graph-carousel
+        :key="Object.keys(normalOzoneMapsNorthern)"
+        :graphs="normalOzoneMapsNorthern"
+      ></graph-carousel>
+    </section>
+
+    <section v-if="ozoneMapTab === 'southern'">
+      <h2>{{ $t('data.products.normal-ozone-maps.southernDesc') }}</h2>
+      <graph-carousel
+        :key="Object.keys(normalOzoneMapsSouthern)"
+        :graphs="normalOzoneMapsSouthern"
+      ></graph-carousel>
+    </section>
+  </v-container>
+</template>
+
+<script>
+import GraphCarousel from '~/components/GraphCarousel'
+export default {
+  components: {
+    'graph-carousel': GraphCarousel,
+  },
+  data() {
+    return {
+      baseOzoneClimatologyURL: `${this.$config.WOUDC_UI_WAF_URL}/products/ozone_maps/climatology/`,
+      ozoneMapTab: 'global',
+      normalozoneMapTypes: ['global', 'northern', 'southern'],
+      months: [
+        'jan',
+        'feb',
+        'mar',
+        'apr',
+        'may',
+        'jun',
+        'jul',
+        'aug',
+        'sept',
+        'oct',
+        'nov',
+        'dec',
+      ],
+    }
+  },
+  head() {
+    return {
+      title: this.$t('data.products.normal-ozone-maps.title'),
+      titleTemplate: this.$titleTemplate(
+        this.$t('common.woudc'),
+        this.$t('common.woudcFull')
+      ),
+      meta: [
+        {
+          hid: 'description',
+          name: 'description',
+          content: this.$t('data.products.normal-ozone-maps.description'),
+        },
+        {
+          hid: 'keywords',
+          name: 'keywords',
+          content: this.$t('data.products.normal-ozone-maps.keywords'),
+        },
+      ],
+    }
+  },
+  computed: {
+    normalOzoneMapsGlobal() {
+      const { baseOzoneClimatologyURL } = this
+      const ozoneMaps = this.months.map((month, index) => {
+        const paddedNumber = (index + 1).toString().padStart(2, '0')
+        const caption = this.$t(
+          `data.products.normal-ozone-maps.captions.globe.${month}`
+        )
+        const url = `${baseOzoneClimatologyURL}/gl_cl/to${paddedNumber}.gif`
+        return { caption, url }
+      })
+
+      return ozoneMaps
+    },
+    normalOzoneMapsNorthern() {
+      const { baseOzoneClimatologyURL } = this
+      const ozoneMaps = this.months.map((month, index) => {
+        const paddedNumber = (index + 1).toString().padStart(2, '0')
+        const caption = this.$t(
+          `data.products.normal-ozone-maps.captions.northern.${month}`
+        )
+        const url = `${baseOzoneClimatologyURL}/nh_cl/to${paddedNumber}.gif`
+        return { caption, url }
+      })
+
+      return ozoneMaps
+    },
+
+    normalOzoneMapsSouthern() {
+      const { baseOzoneClimatologyURL } = this
+      const ozoneMaps = this.months.map((month, index) => {
+        const paddedNumber = (index + 1).toString().padStart(2, '0')
+        const caption = this.$t(
+          `data.products.normal-ozone-maps.captions.southern.${month}`
+        )
+        const url = `${baseOzoneClimatologyURL}/sh_cl/to${paddedNumber}.gif`
+        return { caption, url }
+      })
+
+      return ozoneMaps
+    },
+  },
+  created() {
+    const sanitizedOzoneType = encodeURIComponent(this.$route.query.type)
+    if (this.normalozoneMapTypes.includes(sanitizedOzoneType)) {
+      this.normalozoneMapTypes = sanitizedOzoneType
+    }
+  },
+}
+</script>
+
+<style>
+.recent {
+  max-width: 800px;
+}
+</style>


### PR DESCRIPTION
Created the normal-ozone-maps page in pages/data/products/
There are 3 tabs, globe / southern hemisphere / northern hemisphere, where each tabs display 12 maps, for each month, in the graph-carousel format.   
Edits were made to the index.vue file to add a link for the normal-ozone-maps under Ozone maps.  
Edits were also made to en.json and fr.json.

Issue:
Create "Maps of normal ozone" page; page migration from exp-studies website 
#1200